### PR TITLE
Fix singularity generation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,7 @@
         singularity =
           nixpkgs.legacyPackages.${system}.singularity-tools.buildImage {
             name = "jv2-${version}";
-            diskSize = 1024 * 250;
+            diskSize = 1024 * 500;
             contents = [
               self.packages.${system}.mython
               self.packages.${system}.frontend

--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,8 @@
         singularity =
           nixpkgs.legacyPackages.${system}.singularity-tools.buildImage {
             name = "jv2-${version}";
-            diskSize = 1024 * 500;
+            diskSize = 1024 * 50;
+            memSize = 1024 * 2;
             contents = [
               self.packages.${system}.mython
               self.packages.${system}.frontend


### PR DESCRIPTION
This PR seems to (hopefully!) address issues with singularity generation where the assembly of the image would complain about running out of space. Hours of investigation suggest that this is not completely accurate - since the singularity build process uses the system tmpfs it is quite easy to exhaust the available ramdisk on a modest host VM. As it seems not possible to force a disk-based tmpfs without access to the host VM setup itself, the outlook was bleak....

...until the `memSize` parameter is used. This restricts the resident memory size to a practical value, and at a value of 1.5 Gb gets us over the line.