### PR TITLE
225 Journals for RB Directories

### DIFF
--- a/backend/src/jv2backend/generateRoutes.py
+++ b/backend/src/jv2backend/generateRoutes.py
@@ -24,8 +24,8 @@ def add_routes(
         """List available NeXuS files in a target directory
 
         The POST data should contain:
-               rootUrl: The root network or disk location for journals [UNUSED]
-        data_directory: The data file directory to list
+              rootUrl: The root network or disk location for journals [UNUSED]
+        dataDirectory: The data file directory to list
 
         :return: The number of NeXuS files found
         """
@@ -35,7 +35,7 @@ def add_routes(
         except InvalidRequest as exc:
             return jsonify(f"Error: {str(exc)}")
 
-        logging.debug(f"Scan for NeXus files in data ditrctory \
+        logging.debug(f"Scan for NeXuS files in data directory \
                       {postData.data_directory}...")
 
         return journalGenerator.list_files(postData.data_directory)
@@ -45,10 +45,11 @@ def add_routes(
         """Generates journals and accompanying index file for a target dir
 
         The POST data should contain:
-               rootUrl: The root network or disk location for the journal
-             directory: The directory in rootUrl containing the journal
-        data_directory: Location of the run data to scan
-              filename: Name of the target index file to generate
+                 rootUrl: The root network or disk location for the journal
+               directory: The directory in rootUrl containing the journal
+           dataDirectory: Location of the run data to scan
+        dataOrganisation: How the data is to be organised
+                filename: Name of the target index file to generate
 
         :return: A JSON-formatted list of new run data, or None
         """

--- a/backend/src/jv2backend/generateRoutes.py
+++ b/backend/src/jv2backend/generateRoutes.py
@@ -56,7 +56,8 @@ def add_routes(
         try:
             postData = RequestData(request.json, journalLibrary,
                                    require_filename=True,
-                                   require_data_directory=True)
+                                   require_data_directory=True,
+                                   require_parameter="dataOrganisation")
         except InvalidRequest as exc:
             return jsonify(f"Error: {str(exc)}")
 

--- a/backend/src/jv2backend/io/journalGenerator.py
+++ b/backend/src/jv2backend/io/journalGenerator.py
@@ -115,11 +115,17 @@ class JournalGenerator:
 
         # Create organised journals for the run data
         journals = {}
+        if requestData.parameter == "Directory":
+            sortKey = "data_directory"
+        elif requestData.parameter == "RBNumber":
+            sortKey = "experiment_identifier"
+        logging.debug(f"Sorting key is {sortKey}")
+
         for run in runData:
-            # If the data directory isn't already in the dict, add it now
-            if run["data_directory"] not in journals:
-                journals[run["data_directory"]] = []
-            journals[run["data_directory"]].append(run)
+            # If the sorting key isn't already in the dict, add it now
+            if run[sortKey] not in journals:
+                journals[run[sortKey]] = []
+            journals[run[sortKey]].append(run)
 
         # Create and write index and journal files
         indexRoot = ET.Element("journal")
@@ -140,8 +146,12 @@ class JournalGenerator:
                     dataEntry.text = run[d]
 
             # Write the child journal file
-            with open(url_join(requestData.url, journalFilename), "wb") as f:
-                ET.ElementTree(journalRoot).write(f)
+            try:
+                with open(url_join(requestData.url,
+                                   journalFilename), "wb") as f:
+                    ET.ElementTree(journalRoot).write(f)
+            except Exception as exc:
+                return jsonify(f"Error: {str(exc)}")
 
             # Add an entry in the index file
             indexEntry = ET.SubElement(indexRoot, "file")
@@ -156,4 +166,4 @@ class JournalGenerator:
         with open(requestData.file_url, "wb") as f:
             ET.ElementTree(indexRoot).write(f)
 
-        return jsonify("Success")
+        return jsonify("SUCCESS")

--- a/backend/src/jv2backend/io/journalGenerator.py
+++ b/backend/src/jv2backend/io/journalGenerator.py
@@ -99,8 +99,7 @@ class JournalGenerator:
     def scan_files(self, requestData: RequestData):
         """Generate an index file containing journal information
 
-        :param requestData: RequestData object containing index file details
-        :return: A JSON response with the journal list or an error string
+        :param requestData: RequestData object containing the necessary info
 
         Search all folders in the data file directory and generate a set of
         journal files and an accompanying index file describing the contents.

--- a/backend/src/jv2backend/journalRoutes.py
+++ b/backend/src/jv2backend/journalRoutes.py
@@ -26,9 +26,10 @@ def add_routes(
         """Return the list of journal files in a specified location
 
         The POST data should contain:
-             rootUrl: The root network or disk location for the journals
-           directory: The directory in rootUrl to probe for journals
-            filename: Name of the index file in the directory
+              rootUrl: The root network or disk location for the journals
+            directory: The directory in rootUrl to probe for journals
+        dataDirectory: Associated run data location
+             filename: Name of the index file in the directory
 
         :return: A JSON response containing available journals in a
                  list(BasicJournalFile), or an error

--- a/backend/src/jv2backend/requestData.py
+++ b/backend/src/jv2backend/requestData.py
@@ -71,37 +71,38 @@ class RequestData:
         self._journal_collection = (library[self._full_url] if
                                     self._full_url in library else None)
         if require_in_library and self._journal_collection is None:
-            raise InvalidRequest(f"No collection {self._full_url} in library.")
+            raise InvalidRequest(f"No collection '{self._full_url}' "
+                                 f"in library.")
 
         # Was a data directory provided / required?
         self._data_directory = (requestData["dataDirectory"]
                                 if "dataDirectory" in requestData else None)
         if require_data_directory and self._data_directory is None:
-            raise InvalidRequest(f"Data directory required for URL \
-                          {self._full_url}.")
+            raise InvalidRequest(f"Data directory required for URL "
+                                 f"'{self._full_url}'.")
 
         # Was an optional filename provided / required?
         self._filename = (requestData["filename"] if "filename" in
                           requestData else None)
         if require_filename and self._filename is None:
-            raise InvalidRequest(f"Filename required for URL \
-                                 {self._full_url}.")
+            raise InvalidRequest(f"Filename required for URL "
+                                 f"'{self._full_url}'.")
 
         # Were run number(s) provided / required?
         if "runNumbers" in requestData:
             self._run_numbers = requestData["runNumbers"]
         if require_run_numbers and len(self._run_numbers) == 0:
-            raise InvalidRequest("Run number(s) required but were not \
-                                 provided.")
+            raise InvalidRequest("Run number(s) required but were not "
+                                 "provided.")
 
         # Was an additional parameter provided / required?
-        if require_parameter:
+        if require_parameter is not None:
             if require_parameter in requestData:
                 self._parameter = requestData[require_parameter]
             else:
-                raise InvalidRequest(f"Additional parameter \
-                                     {require_parameter} \
-                                     required but was not provided.")
+                raise InvalidRequest(f"Additional parameter "
+                                     f"'{require_parameter}' "
+                                     f"required but was not provided.")
 
     @property
     def url(self) -> str:

--- a/backend/src/jv2backend/requestData.py
+++ b/backend/src/jv2backend/requestData.py
@@ -9,17 +9,12 @@ from jv2backend.utils import url_join
 class InvalidRequest(Exception):
     status_code = 400
 
-    def __init__(self, message, status_code=None, payload=None):
+    def __init__(self, message):
         Exception.__init__(self)
-        self.message = message
-        if status_code is not None:
-            self.status_code = status_code
-        self.payload = payload
+        self._message = message
 
-    def to_dict(self):
-        rv = dict(self.payload or ())
-        rv['message'] = self.message
-        return rv
+    def __str__(self):
+        return self._message
 
 
 class RequestData:

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -306,8 +306,7 @@ void Backend::generateJournals(const JournalSource &source, HttpRequestWorker::H
     QJsonObject data;
     data["rootUrl"] = source.rootUrl();
     data["dataDirectory"] = source.runDataDirectory();
-    if (!source.indexFile().isEmpty())
-        data["filename"] = source.indexFile();
+    data["filename"] = source.indexFile();
 
     postRequest(createRoute("generate/scan"), data, handler);
 }

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -136,8 +136,7 @@ void Backend::listJournals(const JournalSource &source, const QString &journalDi
     data["rootUrl"] = source.rootUrl();
     data["directory"] = journalDirectory;
     data["dataDirectory"] = source.runDataDirectory();
-    if (!source.indexFile().isEmpty())
-        data["filename"] = source.indexFile();
+    data["filename"] = source.indexFile();
 
     postRequest(createRoute("journals/list"), data, handler);
 }

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -307,6 +307,7 @@ void Backend::generateJournals(const JournalSource &source, HttpRequestWorker::H
     data["rootUrl"] = source.rootUrl();
     data["dataDirectory"] = source.runDataDirectory();
     data["filename"] = source.indexFile();
+    data["dataOrganisation"] = JournalSource::dataOrganisationType(source.runDataOrganisation());
 
     postRequest(createRoute("generate/scan"), data, handler);
 }

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -286,10 +286,12 @@ void Backend::getNexusDetectorAnalysis(const Locator &location, int runNo, HttpR
  */
 
 // List data directory for the specified source
-void Backend::listDataDirectory(const JournalSource &source, HttpRequestWorker::HttpRequestHandler handler)
+void Backend::listDataDirectory(const JournalSource &source, const QString &journalDirectory,
+                                HttpRequestWorker::HttpRequestHandler handler)
 {
     QJsonObject data;
     data["rootUrl"] = source.rootUrl();
+    data["directory"] = journalDirectory;
     data["dataDirectory"] = source.runDataDirectory();
 
     postRequest(createRoute("generate/list"), data, handler);

--- a/frontend/backend.h
+++ b/frontend/backend.h
@@ -107,7 +107,8 @@ class Backend : public QObject
      */
     public:
     // List data directory for the specified source
-    void listDataDirectory(const JournalSource &source, HttpRequestWorker::HttpRequestHandler handler = {});
+    void listDataDirectory(const JournalSource &source, const QString &journalDirectory,
+                           HttpRequestWorker::HttpRequestHandler handler = {});
     // Generate journals for the specified source
     void generateJournals(const JournalSource &source, HttpRequestWorker::HttpRequestHandler handler = {});
 };

--- a/frontend/data/sources.xml
+++ b/frontend/data/sources.xml
@@ -1,6 +1,7 @@
 <xml>
 	<sources>
-		<source name="ISIS Archive" type="ISISNetwork" rootUrl="http://data.isis.rl.ac.uk/journals" indexFile="journal_main.xml" byInstrument="true" dataDirectory="/archive"/>
-		<source name="Local" type="DiskByDirectory" rootUrl="/home/ty11203/TestData/Directories/journals" indexFile="journal_main.xml" dataDirectory="/home/ty11203/TestData/Directories"/>
+		<source name="ISIS Archive" type="ISISNetwork" rootUrl="http://data.isis.rl.ac.uk/journals" indexFile="journal_main.xml" instrumentSubdirs="true" dataDirectory="/archive"/>
+		<source name="Local" type="Disk" rootUrl="/home/ty11203/TestData/Directories/journals" indexFile="Local.xml" dataDirectory="/home/ty11203/TestData/Directories" dataOrganisation="Directory"/>
+		<source name="Local RB" type="Disk" rootUrl="/home/ty11203/TestData/Directories/journals" indexFile="Local_by_RB.xml" instrumentSubdirs="true" dataDirectory="/home/ty11203/TestData/RB_Directories" dataOrganisation="RBNumber"/>
 	</sources>
 </xml>

--- a/frontend/data/sources.xml
+++ b/frontend/data/sources.xml
@@ -1,7 +1,7 @@
 <xml>
 	<sources>
 		<source name="ISIS Archive" type="ISISNetwork" rootUrl="http://data.isis.rl.ac.uk/journals" indexFile="journal_main.xml" instrumentSubdirs="true" dataDirectory="/archive"/>
-		<source name="Local" type="Disk" rootUrl="/home/ty11203/TestData/Directories/journals" indexFile="Local.xml" dataDirectory="/home/ty11203/TestData/Directories" dataOrganisation="Directory"/>
-		<source name="Local RB" type="Disk" rootUrl="/home/ty11203/TestData/Directories/journals" indexFile="Local_by_RB.xml" instrumentSubdirs="true" dataDirectory="/home/ty11203/TestData/RB_Directories" dataOrganisation="RBNumber"/>
+		<source name="Local" type="Disk" rootUrl="/home/ty11203/TestData/journals" indexFile="Local.xml" dataDirectory="/home/ty11203/TestData/Directories" dataOrganisation="Directory"/>
+		<source name="Local RB" type="Disk" rootUrl="/home/ty11203/TestData/journals" indexFile="Local_by_RB.xml" instrumentSubdirs="true" dataDirectory="/home/ty11203/TestData/RB_Directories" dataOrganisation="RBNumber"/>
 	</sources>
 </xml>

--- a/frontend/generation.cpp
+++ b/frontend/generation.cpp
@@ -2,11 +2,7 @@
 // Copyright (c) 2023 Team JournalViewer and contributors
 
 #include "mainWindow.h"
-#include <QJsonArray>
 #include <QMessageBox>
-#include <QNetworkReply>
-#include <QSettings>
-#include <QTimer>
 
 // Handle returned directory list result
 void MainWindow::handleListDataDirectory(const JournalSource &source, HttpRequestWorker *worker)

--- a/frontend/instruments.cpp
+++ b/frontend/instruments.cpp
@@ -95,13 +95,13 @@ void MainWindow::setCurrentInstrument(QString name)
     cachedMassSearch_.clear();
 
     // Make sure we have a valid journal source before we request any data
-    if (!currentJournalSource_ || !currentJournalSource().organisedByInstrument())
+    if (!currentJournalSource_ || !currentJournalSource().instrumentSubdirectories())
         return;
 
     updateForCurrentSource(JournalSource::JournalSourceState::Loading);
 
     backend_.listJournals(currentJournalSource(),
-                          currentJournalSource().organisedByInstrument() ? currentInstrument().journalDirectory() : "",
+                          currentJournalSource().instrumentSubdirectories() ? currentInstrument().journalDirectory() : "",
                           [=](HttpRequestWorker *worker) { handleListJournals(worker); });
 }
 

--- a/frontend/journalSource.cpp
+++ b/frontend/journalSource.cpp
@@ -10,8 +10,8 @@ QString JournalSource::journalSourceType(JournalSource::JournalSourceType type)
     {
         case (JournalSourceType::ISISNetwork):
             return "ISISArchive";
-        case (JournalSourceType::DiskByDirectory):
-            return "DiskByDirectory";
+        case (JournalSourceType::Disk):
+            return "Disk";
         default:
             throw(std::runtime_error("JournalSource type not known and can't be converted to a QString.\n"));
     }
@@ -22,16 +22,41 @@ JournalSource::JournalSourceType JournalSource::journalSourceType(QString typeSt
 {
     if (typeString.toLower() == "isisnetwork")
         return JournalSourceType::ISISNetwork;
-    else if (typeString.toLower() == "diskbydirectory")
-        return JournalSourceType::DiskByDirectory;
+    else if (typeString.toLower() == "disk")
+        return JournalSourceType::Disk;
     else
         throw(std::runtime_error("JournalSource string can't be converted to a JournalSourceType.\n"));
 }
 
+// Return text string for specified DataOrganisationType
+QString JournalSource::dataOrganisationType(JournalSource::DataOrganisationType type)
+{
+    switch (type)
+    {
+        case (DataOrganisationType::Directory):
+            return "Directory";
+        case (DataOrganisationType::RBNumber):
+            return "RBNumber";
+        default:
+            throw(std::runtime_error("DataOrganisationType not known and can't be converted to a QString.\n"));
+    }
+}
+
+// Convert text string to DataOrganisationType
+JournalSource::DataOrganisationType JournalSource::dataOrganisationType(QString typeString)
+{
+    if (typeString.toLower() == "directory")
+        return DataOrganisationType::Directory;
+    else if (typeString.toLower() == "rbnumber")
+        return DataOrganisationType::RBNumber;
+    else
+        throw(std::runtime_error("DataOrganisationType string can't be converted to a DataOrganisationType.\n"));
+}
+
 JournalSource::JournalSource(QString name, JournalSourceType type, QString rootUrl, QString runDataDirectory, QString indexFile,
-                             bool organisedByInstrument)
+                             bool instrumentSubdirectories, DataOrganisationType runDataOrganisation)
     : name_(name), type_(type), rootUrl_(rootUrl), runDataDirectory_(runDataDirectory), indexFile_(indexFile),
-      organisedByInstrument_(organisedByInstrument)
+      instrumentSubdirectories_(instrumentSubdirectories), runDataOrganisation_(runDataOrganisation)
 {
 }
 
@@ -54,8 +79,15 @@ const QString &JournalSource::runDataDirectory() const { return runDataDirectory
 // Return name of the index file in the main directories, if known
 const QString &JournalSource::indexFile() const { return indexFile_; }
 
-// Return whether the data is organised by ISIS instrument
-bool JournalSource::organisedByInstrument() const { return organisedByInstrument_; }
+// Return whether this source has instrument subdirectories
+bool JournalSource::instrumentSubdirectories() const { return instrumentSubdirectories_; }
+
+// Return run data organisation
+JournalSource::DataOrganisationType JournalSource::runDataOrganisation() const { return runDataOrganisation_; }
+
+/*
+ * State
+ */
 
 // Set current state of the journal source
 void JournalSource::setState(JournalSourceState state) { state_ = state; }

--- a/frontend/journalSource.h
+++ b/frontend/journalSource.h
@@ -41,6 +41,7 @@ class JournalSource
         RunDataScanInProgress,
         RunDataScanNoFilesError,
         JournalGenerationInProgress,
+        JournalGenerationError
     };
 
     public:

--- a/frontend/journalSource.h
+++ b/frontend/journalSource.h
@@ -13,12 +13,22 @@ class JournalSource
     enum class JournalSourceType
     {
         ISISNetwork,
-        DiskByDirectory
+        Disk
     };
     // Return text string for specified JournalSource type
     static QString journalSourceType(JournalSourceType type);
     // Convert text string to JournalSource type
     static JournalSourceType journalSourceType(QString typeString);
+    // Data Organisation Types
+    enum class DataOrganisationType
+    {
+        Directory,
+        RBNumber
+    };
+    // Return text string for specified DataOrganisationType
+    static QString dataOrganisationType(DataOrganisationType type);
+    // Convert text string to DataOrganisationType
+    static DataOrganisationType dataOrganisationType(QString typeString);
     // JournalSource States
     enum JournalSourceState
     {
@@ -35,7 +45,7 @@ class JournalSource
 
     public:
     JournalSource(QString name, JournalSourceType type, QString rootUrl, QString runDataDirectory, QString indexFile,
-                  bool organisedByInstrument);
+                  bool instrumentSubdirectories_, DataOrganisationType runDataOrganisation);
 
     /*
      * Basic Data
@@ -51,10 +61,10 @@ class JournalSource
     QString runDataDirectory_;
     // Name of the index file in the main directories, if known
     QString indexFile_;
-    // Whether this source is organised by ISIS instrument
-    bool organisedByInstrument_{true};
-    // Current state of the journal source
-    JournalSourceState state_{JournalSourceState::Loading};
+    // Whether this source has instrument subdirectories
+    bool instrumentSubdirectories_{true};
+    // Run data organisation
+    DataOrganisationType runDataOrganisation_;
 
     public:
     // Return name (used for display)
@@ -67,8 +77,19 @@ class JournalSource
     const QString &runDataDirectory() const;
     // Return name of the index file in the main directories, if known
     const QString &indexFile() const;
-    // Return whether this source is organised by ISIS instrument
-    bool organisedByInstrument() const;
+    // Return whether this source has instrument subdirectories
+    bool instrumentSubdirectories() const;
+    // Return run data organisation
+    DataOrganisationType runDataOrganisation() const;
+
+    /*
+     * State
+     */
+    private:
+    // Current state of the journal source
+    JournalSourceState state_{JournalSourceState::Loading};
+
+    public:
     // Set current state of the journal source
     void setState(JournalSourceState state);
     // Return current state of the journal source

--- a/frontend/journalSources.cpp
+++ b/frontend/journalSources.cpp
@@ -28,7 +28,7 @@ bool MainWindow::parseJournalSources(const QDomDocument &source)
         auto sourceName = sourceElement.attribute("name");
 
         // Get source type
-        auto sourceType = JournalSource::journalSourceType(sourceElement.attribute("type", "DiskByDirectory"));
+        auto sourceType = JournalSource::journalSourceType(sourceElement.attribute("type", "Disk"));
 
         // Get source root URL
         auto sourceRootURL = sourceElement.attribute("rootUrl");
@@ -38,11 +38,14 @@ bool MainWindow::parseJournalSources(const QDomDocument &source)
         auto sourceIndexFile = sourceElement.attribute("indexFile");
 
         // Whether the journals / data are organised by known instrument
-        auto organisedByInstrument = sourceElement.attribute("byInstrument", "false").toLower() == "true";
+        auto organisedByInstrument = sourceElement.attribute("instrumentSubdirs", "false").toLower() == "true";
+
+        // Get run data organisation type
+        auto runDataOrgType = JournalSource::dataOrganisationType(sourceElement.attribute("dataOrganisation", "Directory"));
 
         // Create the source
         auto &journalSource = journalSources_.emplace_back(sourceName, sourceType, sourceRootURL, sourceDataDirectory,
-                                                           sourceIndexFile, organisedByInstrument);
+                                                           sourceIndexFile, organisedByInstrument, runDataOrgType);
     }
 
     // Populate the combo box with options
@@ -102,7 +105,7 @@ void MainWindow::setCurrentJournalSource(std::optional<QString> optName)
     // Reset the state of the source since we can't assume the result of the index request
     currentJournalSource_->get().setState(JournalSource::JournalSourceState::Loading);
 
-    bool orgByInst = currentJournalSource_->get().organisedByInstrument();
+    bool orgByInst = currentJournalSource_->get().instrumentSubdirectories();
     backend_.listJournals(currentJournalSource(), orgByInst ? currentInstrument().journalDirectory() : "",
                           [=](HttpRequestWorker *worker) { handleListJournals(worker); });
 }

--- a/frontend/journalSources.cpp
+++ b/frontend/journalSources.cpp
@@ -120,7 +120,7 @@ const JournalSource &MainWindow::currentJournalSource() const
 }
 
 /*
- * Private SLots
+ * Private Slots
  */
 
 void MainWindow::on_JournalSourceComboBox_currentIndexChanged(int index)

--- a/frontend/journals.cpp
+++ b/frontend/journals.cpp
@@ -111,9 +111,12 @@ void MainWindow::handleListJournals(HttpRequestWorker *worker)
 
         updateForCurrentSource(JournalSource::JournalSourceState::NoIndexFileError);
 
+        bool orgByInst = journalSource.instrumentSubdirectories();
+        auto rootUrl = orgByInst ? QString("%1/%2").arg(currentJournalSource().rootUrl(), currentInstrument().name()) : currentJournalSource().rootUrl();
+
         if (QMessageBox::question(this, "Index File Doesn't Exist",
                                   QString("No index file %1/%2 currently exists.\nWould you like to generate it now?")
-                                      .arg(currentJournalSource().rootUrl(), currentJournalSource().indexFile())) ==
+                                      .arg(rootUrl, currentJournalSource().indexFile())) ==
             QMessageBox::StandardButton::Yes)
         {
             bool orgByInst = currentJournalSource_->get().instrumentSubdirectories();

--- a/frontend/journals.cpp
+++ b/frontend/journals.cpp
@@ -112,12 +112,12 @@ void MainWindow::handleListJournals(HttpRequestWorker *worker)
         updateForCurrentSource(JournalSource::JournalSourceState::NoIndexFileError);
 
         bool orgByInst = journalSource.instrumentSubdirectories();
-        auto rootUrl = orgByInst ? QString("%1/%2").arg(currentJournalSource().rootUrl(), currentInstrument().name()) : currentJournalSource().rootUrl();
+        auto rootUrl = orgByInst ? QString("%1/%2").arg(currentJournalSource().rootUrl(), currentInstrument().name())
+                                 : currentJournalSource().rootUrl();
 
         if (QMessageBox::question(this, "Index File Doesn't Exist",
                                   QString("No index file %1/%2 currently exists.\nWould you like to generate it now?")
-                                      .arg(rootUrl, currentJournalSource().indexFile())) ==
-            QMessageBox::StandardButton::Yes)
+                                      .arg(rootUrl, currentJournalSource().indexFile())) == QMessageBox::StandardButton::Yes)
         {
             bool orgByInst = currentJournalSource_->get().instrumentSubdirectories();
 

--- a/frontend/journals.cpp
+++ b/frontend/journals.cpp
@@ -115,10 +115,14 @@ void MainWindow::handleListJournals(HttpRequestWorker *worker)
                                   QString("No index file %1/%2 currently exists.\nWould you like to generate it now?")
                                       .arg(currentJournalSource().rootUrl(), currentJournalSource().indexFile())) ==
             QMessageBox::StandardButton::Yes)
-            backend_.listDataDirectory(currentJournalSource(),
+        {
+            bool orgByInst = currentJournalSource_->get().instrumentSubdirectories();
+
+            backend_.listDataDirectory(currentJournalSource(), orgByInst ? currentInstrument().journalDirectory() : "",
                                        [=](HttpRequestWorker *worker) { handleListDataDirectory(journalSource, worker); });
 
-        return;
+            return;
+        }
     }
 
     // Add returned journals

--- a/frontend/mainWindow.cpp
+++ b/frontend/mainWindow.cpp
@@ -78,7 +78,7 @@ void MainWindow::updateForCurrentSource(std::optional<JournalSource::JournalSour
     // If the source is OK, we enable relevant controls
     if (source.state() == JournalSource::JournalSourceState::OK)
     {
-        ui_.instrumentButton->setEnabled(source.organisedByInstrument());
+        ui_.instrumentButton->setEnabled(source.instrumentSubdirectories());
         ui_.journalButton->setEnabled(true);
     }
     else

--- a/frontend/mainWindow.h
+++ b/frontend/mainWindow.h
@@ -160,6 +160,8 @@ class MainWindow : public QMainWindow
     private:
     // Handle returned directory list result
     void handleListDataDirectory(const JournalSource &source, HttpRequestWorker *worker);
+    // Handle returned journal generation result
+    void handleScanResult(const JournalSource &source, HttpRequestWorker *worker);
 
     /*
      * Network Handling

--- a/frontend/mainWindow.ui
+++ b/frontend/mainWindow.ui
@@ -442,6 +442,20 @@
               </item>
              </layout>
             </widget>
+            <widget class="QWidget" name="JournalGenerationErrorPage">
+             <layout class="QVBoxLayout" name="verticalLayout_14">
+              <item>
+               <widget class="QLabel" name="JournalGenerationErrorLabel">
+                <property name="text">
+                 <string>Journal Generation Failed!</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </widget>
           </item>
          </layout>


### PR DESCRIPTION
This PR adds in sorting of run data into journals covering individual RB numbers.  There are several issues with the present implementation, notable that the generated journal indices and files are not stored correctly according to instrument (if that option is enabled for the source).

At this point, introducing a more manageable way of storing / retrieving journal files is the next step. Rather than storing journal data in a specified directory structure, we can simply maintain and write the `JournalLibrary` to a given local file.

Closes #225.