### PR TITLE
249 No More Pandas

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -4,8 +4,6 @@
 # """Provide common test fixtures for pytest"""
 from typing import Callable
 from pathlib import Path
-
-import pandas as pd
 import pytest
 
 
@@ -32,18 +30,6 @@ def sample_journallist_xml(test_data_dir) -> bytes:
     """Provide a sample XML list of journal files data"""
     with open(test_data_dir / "journal_main.xml") as handle:
         return handle.read().encode("utf-8")
-
-
-@pytest.fixture()
-def sample_journal_dataframe(sample_journal_xml) -> pd.DataFrame:
-    """Provide a sample dataframe"""
-    return pd.read_xml(sample_journal_xml(), dtype=str)
-
-
-@pytest.fixture()
-def sample_run(sample_journal_dataframe) -> dict:
-    """Provide a sample Run dict"""
-    return sample_journal_dataframe.iloc[0].to_dict()
 
 
 @pytest.fixture()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "wheel", "pandas == 1.5.3"]
+requires = ["setuptools >= 40.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -14,7 +14,6 @@ install_requires =
     h5py
     lxml
     numpy
-    pandas == 1.5.3
     requests
 
 [options.extras_require]

--- a/backend/src/jv2backend/app.py
+++ b/backend/src/jv2backend/app.py
@@ -13,6 +13,7 @@ import jv2backend.serverRoutes
 import jv2backend.journals
 import jv2backend.io.journalLocator
 import jv2backend.io.journalGenerator
+import xml.etree.ElementTree as ElementTree
 
 
 def create_app(inside_gunicorn: bool = True) -> Flask:
@@ -25,14 +26,20 @@ def create_app(inside_gunicorn: bool = True) -> Flask:
     app = Flask(__name__)
     configure_logging(app, inside_gunicorn)
 
+    # Create our main objects
     journalLocator = jv2backend.io.journalLocator.JournalLocator()
     journalGenerator = jv2backend.io.journalGenerator.JournalGenerator()
     journalLibrary = jv2backend.journals.JournalLibrary({})
 
+    # Register Flask routes
     jv2backend.serverRoutes.add_routes(app)
     jv2backend.journalRoutes.add_routes(app, journalLocator, journalLibrary)
     jv2backend.generateRoutes.add_routes(app, journalGenerator, journalLibrary)
     jv2backend.nexusRoutes.add_routes(app, journalLibrary)
+
+    # Register XML namespaces
+    ElementTree.register_namespace( '', "http://definition.nexusformat.org/schema/3.0")
+    ElementTree.register_namespace('xsi', "http://www.w3.org/2001/XMLSchema-instance")
 
     return app
 

--- a/backend/src/jv2backend/io/journalLocator.py
+++ b/backend/src/jv2backend/io/journalLocator.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2023 Team JournalViewer and contributors
 
-from typing import Optional, List
+import typing
 from io import BytesIO
 from jv2backend.utils import url_join, lm_to_datetime
 import xml.etree.ElementTree as ElementTree
 from flask import make_response
 from flask.wrappers import Response as FlaskResponse
-import pandas as pd
 import datetime
 import requests
 import logging
@@ -60,20 +59,25 @@ class JournalLocator:
             raise RuntimeError("No source type set.")
 
     @classmethod
-    def _get_journal_run_data(cls, requestData: RequestData) -> pd.DataFrame:
-        """Get the content of the file and parse it with Pandas"""
+    def _get_journal_run_data(
+            cls, requestData: RequestData
+    ) -> ElementTree.Element:
+        """Get the content of the file and parse it with ElementTree"""
+        tree = ElementTree
         if requestData.source_type == SourceType.Network:
             response = requests.get(requestData.journal_file_url(), timeout=3)
             response.raise_for_status()
-            return pd.read_xml(BytesIO(response.content), dtype=str)
+            tree = ElementTree.parse(BytesIO(response.content))
         elif requestData.source_type == SourceType.Cached:
             if requestData.journal_collection is None:
-                return pd.DataFrame
+                tree = ElementTree
         elif requestData.source_type == SourceType.File:
             with open(requestData.file_url, "rb") as file:
-                return pd.read_xml(BytesIO(file.read()), dtype=str)
+                tree = ElementTree.parse(BytesIO(file.read()))
         else:
             raise RuntimeError("No source type set.")
+
+        return tree.getroot()
 
     def get_index(self, requestData: RequestData,
                   journalLibrary: JournalLibrary) -> FlaskResponse:
@@ -186,10 +190,10 @@ class JournalLocator:
         # raise an error
         if requestData.source_type == SourceType.Cached:
             if j is not None:
-                return json_response(j.run_data)
+                return make_response(j.run_data.to_json(), 200)
             else:
                 return make_response(
-                    jsonify({"Error":"Cached journal not found."}), 200
+                    jsonify({"Error": "Cached journal not found."}), 200
                 )
 
         # If we already have this journal file in the collection, check its
@@ -204,7 +208,7 @@ class JournalLocator:
 
         # Not up-to-date, so get the full file content and update modtime
         try:
-            runData = self._get_journal_run_data(requestData)
+            treeRoot = self._get_journal_run_data(requestData)
         except (requests.HTTPError, requests.ConnectionError,
                 FileNotFoundError) as exc:
             return make_response(jsonify({"Error": str(exc)}), 200)
@@ -212,7 +216,7 @@ class JournalLocator:
             return make_response(jsonify({"Error": str(exc)}), 200)
 
         # Store the updated run data and modtime
-        j.run_data = JournalData(runData)
+        j.run_data = JournalData.from_element_tree(treeRoot)
         j.last_modified = current_last_modified
 
         # Store the most-recent (highest) run number in the journal for future
@@ -257,12 +261,12 @@ class JournalLocator:
 
         # Changed, so read full data and store the whole thing
         try:
-            runData = self._get_journal_run_data(requestData)
+            treeRoot = self._get_journal_run_data(requestData)
         except (requests.HTTPError, requests.ConnectionError,
                 FileNotFoundError) as exc:
             return make_response(jsonify({"Error": str(exc)}), 200)
         j.last_modified = current_last_modified
-        j.run_data = JournalData(runData)
+        j.run_data = JournalData.from_element_tree(treeRoot)
 
         # Get the last run number
         old_last_run_number = j.last_run_number
@@ -275,7 +279,7 @@ class JournalLocator:
         return make_response(json_response(j.run_data.search("run_number",
                                                f">{old_last_run_number}")), 200)
 
-    def filename_for_run(self, instrument: str, run: str) -> Optional[str]:
+    def filename_for_run(self, instrument: str, run: str) -> typing.Optional[str]:
         """Find the journal file that contains the given run
 
         :param instrument: The instrument name

--- a/backend/src/jv2backend/io/journalLocator.py
+++ b/backend/src/jv2backend/io/journalLocator.py
@@ -204,7 +204,7 @@ class JournalLocator:
                 requestData
             )
             if current_last_modified == j.last_modified:
-                return json_response(j.run_data)
+                return make_response(j.run_data.to_json(), 200)
 
         # Not up-to-date, so get the full file content and update modtime
         try:
@@ -223,7 +223,7 @@ class JournalLocator:
         # reference
         j.last_run_number = j.run_data.get_last_run_number
 
-        return make_response(json_response(j.run_data), 200)
+        return make_response(j.run_data.to_json(), 200)
 
     def get_all_journal_data(self, collection: JournalCollection) -> None:
         """Retrieve all run data for all journals listed in the collection

--- a/backend/src/jv2backend/journals.py
+++ b/backend/src/jv2backend/journals.py
@@ -7,7 +7,6 @@ import typing
 import datetime as dt
 from typing import Optional, Sequence
 from jv2backend.utils import url_join
-import pandas as pd
 import xml.etree.ElementTree as ElementTree
 import json
 import logging

--- a/backend/src/jv2backend/journals.py
+++ b/backend/src/jv2backend/journals.py
@@ -213,11 +213,10 @@ class JournalData:
         :param run_number: Run number to select
         :return: A dict describing the Run or None if the run does not exist
         """
-        matches = self._data[self._data["run_number"] == str(run_number)]
-        if len(matches) == 0:
-            return None
+        if run_number in self._data:
+            return self._data[run_number]
         else:
-            return matches.to_dict(orient="records")[0]
+            return None
 
     def search(
         self, run_field: str, user_input: str, case_sensitive: bool = False

--- a/backend/src/jv2backend/tests/test_journalCollection.py
+++ b/backend/src/jv2backend/tests/test_journalCollection.py
@@ -4,7 +4,6 @@
 from jv2backend.journals import JournalCollection, JournalFile, JournalData
 import xml.etree.ElementTree as ElementTree
 import datetime
-import pandas
 import pytest
 
 # Construct two test journals

--- a/backend/src/jv2backend/tests/test_journalCollection.py
+++ b/backend/src/jv2backend/tests/test_journalCollection.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Team JournalViewer and contributors
 
 from jv2backend.journals import JournalCollection, JournalFile, JournalData
+import xml.etree.ElementTree as ElementTree
 import datetime
 import pandas
 import pytest
@@ -11,12 +12,12 @@ with open("jv2backend/tests/data/simpleRunData1.xml", "rb") as f1:
     journal1 = JournalFile("Journal A", "/a/local/disk",
                            "data", "simpleRunData1.xml",
                            "/fake/data/root", datetime.datetime.now(),
-                           JournalData(pandas.read_xml(f1, dtype=str)))
+                           JournalData.from_element_tree(ElementTree.parse(f1)))
 with open("jv2backend/tests/data/simpleRunData2.xml", "rb") as f2:
     journal2 = JournalFile("Journal B", "/a/local/disk",
                            "data", "simpleRunData2.xml",
                            "/fake/data/root", datetime.datetime.now(),
-                           JournalData(pandas.read_xml(f2, dtype=str)))
+                           JournalData.from_element_tree(ElementTree.parse(f2)))
 
 
 def test_constructor():

--- a/backend/src/jv2backend/tests/test_journalData.py
+++ b/backend/src/jv2backend/tests/test_journalData.py
@@ -2,32 +2,30 @@
 # Copyright (c) 2023 Team JournalViewer and contributors
 
 from jv2backend.journals import JournalData
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ElementTree
 import json
-import pandas
 import pytest
 
 # Load test run data
 with open("jv2backend/tests/data/simpleRunData1.xml", "rb") as f:
-    runData = pandas.read_xml(f, dtype=str)
-#    runData = ET.parse(f)
+    runDataTree = ElementTree.parse(f)
 
 
 def test_basic_constructor():
-    data = JournalData(runData)
+    data = JournalData.from_element_tree(runDataTree)
 
     assert data.run_count == 6
 
 
 def test_run_data_ranges():
-    data = JournalData(runData)
+    data = JournalData.from_element_tree(runDataTree)
 
     assert data.get_last_run_number == 9
 
 
 @pytest.mark.parametrize("run_number", [1, 2, 3, 6, 8, 9])
 def test_run_data_contains_run_number(run_number):
-    data = JournalData(runData)
+    data = JournalData.from_element_tree(runDataTree)
 
     assert run_number in data
     assert data.run(run_number) is not None
@@ -35,7 +33,7 @@ def test_run_data_contains_run_number(run_number):
 
 @pytest.mark.parametrize("run_number", [0, 4, 5, 7, 99, 12301])
 def test_run_data_does_not_contain_run_number(run_number):
-    data = JournalData(runData)
+    data = JournalData.from_element_tree(runDataTree)
 
     assert run_number not in data
     assert data.run(run_number) is None
@@ -43,7 +41,7 @@ def test_run_data_does_not_contain_run_number(run_number):
 
 @pytest.mark.parametrize("case_sensitive", [True, False])
 def test_search_by_user_name_field_uses_a_contains_check_not_exact_match(case_sensitive):
-    data = JournalData(runData)
+    data = JournalData.from_element_tree(runDataTree)
 
     search_results = data.search("user_name", "devlin", case_sensitive)
 
@@ -55,7 +53,7 @@ def test_search_by_user_name_field_uses_a_contains_check_not_exact_match(case_se
 
 @pytest.mark.parametrize("case_sensitive", [True, False])
 def test_search_by_experiment_identifier_uses_exact_string_matching(case_sensitive):
-    data = JournalData(runData)
+    data = JournalData.from_element_tree(runDataTree)
 
     search_results = data.search("experiment_identifier", "123456", case_sensitive)
     assert search_results.run_count == 0
@@ -66,7 +64,7 @@ def test_search_by_experiment_identifier_uses_exact_string_matching(case_sensiti
 
 @pytest.mark.parametrize("case_sensitive", [True, False])
 def test_search_by_title_uses_a_contains_check_and_not_exact_match(case_sensitive):
-    data = JournalData(runData)
+    data = JournalData.from_element_tree(runDataTree)
 
     search_results = data.search("title", "science", case_sensitive)
     if case_sensitive:
@@ -76,7 +74,7 @@ def test_search_by_title_uses_a_contains_check_and_not_exact_match(case_sensitiv
 
 
 def test_search_by_run_number_uses_a_range_check_assuming_user_gives_start_end():
-    data = JournalData(runData)
+    data = JournalData.from_element_tree(runDataTree)
 
     search_results = data.search("run_number", "10-1000")
     assert search_results.run_count == 0
@@ -92,7 +90,7 @@ def test_search_by_run_number_uses_a_range_check_assuming_user_gives_start_end()
 
 
 def test_search_by_run_number_uses_a_range_check_given_range_operator():
-    data = JournalData(runData)
+    data = JournalData.from_element_tree(runDataTree)
 
     search_results = data.search("run_number", ">6")
     assert search_results.run_count == 2
@@ -103,7 +101,7 @@ def test_search_by_run_number_uses_a_range_check_given_range_operator():
 
 
 def test_search_by_start_time_treating_input_as_datetime_and_equivalent_to_start_date():
-    data = JournalData(runData)
+    data = JournalData.from_element_tree(runDataTree)
 
     search_results = data.search("start_time", "2023/02/03-2023/02/04")
 

--- a/backend/src/jv2backend/tests/test_journalFile.py
+++ b/backend/src/jv2backend/tests/test_journalFile.py
@@ -3,7 +3,6 @@
 
 from jv2backend.journals import BasicJournalFile, JournalFile, JournalData
 import datetime
-import pandas
 import typing
 
 # Journal Data
@@ -27,7 +26,7 @@ def test_derived_constructor():
     derived = JournalFile(JOURNAL_NAME, JOURNAL_ROOT_URL,
                           JOURNAL_DIRECTORY, JOURNAL_FILENAME,
                           JOURNAL_DATA_ROOT, JOURNAL_MODTIME,
-                          JournalData(pandas.DataFrame()))
+                          JournalData({}))
 
     _test_journal_data(derived)
     assert derived.run_data.run_count == 0
@@ -37,7 +36,7 @@ def test_basic_from_derived():
     derived = JournalFile(JOURNAL_NAME, JOURNAL_ROOT_URL,
                           JOURNAL_DIRECTORY, JOURNAL_FILENAME,
                           JOURNAL_DATA_ROOT, JOURNAL_MODTIME,
-                          JournalData(pandas.DataFrame()))
+                          JournalData({}))
     basic = JournalFile.from_derived(derived)
 
     _test_journal_data(basic)

--- a/backend/src/jv2backend/tests/test_requestData.py
+++ b/backend/src/jv2backend/tests/test_requestData.py
@@ -5,7 +5,6 @@ from jv2backend.requestData import RequestData, InvalidRequest, SourceType
 from jv2backend.journals import JournalLibrary, JournalCollection, JournalFile, JournalData
 import datetime
 import pytest
-import pandas
 
 # Test Data
 POST_SOURCE_ID = "/my/source/id"
@@ -137,7 +136,7 @@ def test_journal_required_to_be_already_in_collection():
     journals = [JournalFile("Mr Journal", POST_JOURNAL_ROOT_URL,
                             "", POST_JOURNAL_FILENAME,
                             "", datetime.datetime.now(),
-                            JournalData(pandas.DataFrame()))]
+                            JournalData({}))]
     library = JournalLibrary({POST_SOURCE_ID: JournalCollection(journals)})
     try:
         data = RequestData(post_data, library, require_journal_file=True, require_in_library=True)
@@ -155,7 +154,7 @@ def test_journal_required_to_be_already_in_collection_but_is_not():
     journals = [JournalFile("Mr Journal", POST_JOURNAL_ROOT_URL,
                             "", POST_JOURNAL_FILENAME,
                             "", datetime.datetime.now(),
-                            JournalData(pandas.DataFrame()))]
+                            JournalData({}))]
     library = JournalLibrary({POST_SOURCE_ID: JournalCollection(journals)})
     with pytest.raises(InvalidRequest) as exc:
         data = RequestData(post_data, library, require_journal_file=True, require_in_library=True)

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,6 @@
           gunicorn
           h5py
           lxml
-          pandas
           requests
           setuptools
           virtualenv


### PR DESCRIPTION
This PR removes use of `pandas` for data reading / storage, and we move to a simpler `dict`-based method.

Run data search functions still refer to / assume `pandas` objects here, but this will be rectified in a subsequent PR handling complete overhaul of that aspect of the code.

Closes #249.