### PR TITLE
263 Explicit Parameters

### DIFF
--- a/backend/src/jv2backend/journalCollection.py
+++ b/backend/src/jv2backend/journalCollection.py
@@ -24,14 +24,14 @@ class JournalCollection:
                  library_key: str = None,
                  index_root_url: str = None,
                  index_filename: str = None,
-                 run_data_root_url: str = None,
+                 run_data_url: str = None,
                  last_modified: datetime.datetime = None,
                  journals: [] = None):
         self._source_type = source_type
         self._library_key = library_key
         self._index_root_url = index_root_url
         self._index_filename = index_filename
-        self._run_data_root_url = run_data_root_url
+        self._run_data_url = run_data_url
         self._last_modified = last_modified
         self._journals = [] if journals is None else journals
 
@@ -44,13 +44,41 @@ class JournalCollection:
         j = self.__getitem__(key)
         return j is not None
 
+    @property
+    def library_key(self) -> str:
+        """Return the library key for the collection"""
+        return self._library_key
+
     def get_index_file_url(self) -> str:
         """Return the full URL to the journal"""
         return url_join(self._index_root_url, self._index_filename)
 
     @property
+    def run_data_url(self) -> str:
+        """Return the run data location"""
+        return self._run_data_url
+
+    def add_journal(self, display_name: str, source_type: SourceType,
+                    journal_filename: str, data_directory: str,
+                    run_data: {} = None) -> Journal:
+        """Add a new journal to the list"""
+        journal = Journal(
+            display_name,
+            source_type,
+            self._library_key,
+            self._index_root_url,
+            journal_filename,
+            data_directory,
+            datetime.datetime.now(),
+            {} if run_data is None else run_data
+        )
+
+        self._journals.append(journal)
+        return journal
+
+    @property
     def journals(self):
-        """Return the current journals array"""
+        """Return the current journals list"""
         return self._journals
 
     def get_journal_count(self):
@@ -175,7 +203,7 @@ class JournalCollection:
                     cycle_dir = j.attrib["name"].replace("journal", "cycle")
                     cycle_dir.replace(".xml", "")
                     data_directory = url_join(
-                        self._run_data_root_url,
+                        self._run_data_url,
                         "Instrument",
                         "data",
                         cycle_dir)

--- a/backend/src/jv2backend/journalCollection.py
+++ b/backend/src/jv2backend/journalCollection.py
@@ -8,11 +8,8 @@ from io import BytesIO
 from jv2backend.utils import url_join, lm_to_datetime
 import jv2backend.select as Selector
 from jv2backend.journal import Journal, SourceType
-from jv2backend.requestData import RequestData
 import jv2backend.userCache
 import xml.etree.ElementTree as ElementTree
-from flask import make_response, jsonify
-from flask.wrappers import Response as FlaskResponse
 import logging
 import json
 import requests

--- a/backend/src/jv2backend/journalLibrary.py
+++ b/backend/src/jv2backend/journalLibrary.py
@@ -102,24 +102,3 @@ class JournalLibrary:
             return json.dumps({"Error": str(exc)})
 
         return collection.to_basic_json()
-
-    def search_collection(self, request_data: RequestData) -> FlaskResponse:
-        """Retrieve run data contained in a collection where it matches all of
-        the specified search query parameters.
-
-        :param request_data: RequestData object containing target source
-        :return: A JSON response with the journal list or an error string
-        """
-        # Check whether the specified collection exists
-        if request_data.library_key() not in self.collections:
-            return make_response(
-                jsonify({"Error": f"No library '{request_data.library_key()}' "
-                                  f"currently exists."}), 200
-            )
-
-        # Get the collection and make sure we have all data for all journals
-        collection = self.collections[request_data.library_key()]
-        collection.get_all_journal_data()
-
-        results = collection.search(request_data.value_map)
-        return make_response(Journal.convert_run_data_to_json_array(results), 200)

--- a/backend/src/jv2backend/journalLibrary.py
+++ b/backend/src/jv2backend/journalLibrary.py
@@ -103,22 +103,6 @@ class JournalLibrary:
 
         return collection.to_basic_json()
 
-    def get_journal_data_updates(self, request_data: RequestData) -> FlaskResponse:
-        """Retrieve new run data contained in a journal file within a collection
-
-        :param request_data: RequestData object containing target source / journal
-        :return: A JSON response with the journal list or an error string
-        """
-        # Check whether the specified collection exists
-        if request_data.library_key() not in self.collections:
-            return make_response(
-                jsonify({"Error": f"No library '{request_data.library_key()}' "
-                                  f"currently exists."}), 200
-            )
-
-        collection = self.collections[request_data.library_key()]
-        return collection.get_updates(request_data)
-
     def search_collection(self, request_data: RequestData) -> FlaskResponse:
         """Retrieve run data contained in a collection where it matches all of
         the specified search query parameters.

--- a/backend/src/jv2backend/journalLibrary.py
+++ b/backend/src/jv2backend/journalLibrary.py
@@ -103,22 +103,6 @@ class JournalLibrary:
 
         return collection.to_basic_json()
 
-    def get_journal_data(self, request_data: RequestData) -> FlaskResponse:
-        """Retrieve run data contained in a journal file within a collection
-
-        :param request_data: RequestData object containing target source / journal
-        :return: A JSON response with the journal list or an error string
-        """
-        # Check whether the specified collection exists
-        if request_data.library_key() not in self.collections:
-            return make_response(
-                jsonify({"Error": f"No library '{request_data.library_key()}' "
-                                  f"currently exists."}), 200
-            )
-
-        collection = self.collections[request_data.library_key()]
-        return collection.get_journal_data(request_data)
-
     def get_journal_data_updates(self, request_data: RequestData) -> FlaskResponse:
         """Retrieve new run data contained in a journal file within a collection
 

--- a/backend/src/jv2backend/journalRoutes.py
+++ b/backend/src/jv2backend/journalRoutes.py
@@ -57,17 +57,27 @@ def add_routes(
         :return: A JSON response containing the journal data, or an error
         """
         try:
-            postData = RequestData(request.json,
-                                   require_journal_file=True)
+            post_data = RequestData(request.json,
+                                    require_journal_file=True)
         except InvalidRequest as exc:
             return make_response(jsonify({"Error": str(exc)}), 200)
 
-        logging.debug(f"Get journal {postData.journal_file_url()} "
-                      f"from '{postData.library_key()}'")
+        logging.debug(f"Get journal {post_data.journal_file_url()} "
+                      f"from '{post_data.library_key()}'")
 
         journalLibrary.list()
 
-        return journalLibrary.get_journal_data(postData)
+        collection = journalLibrary[post_data.library_key()]
+        if collection is None:
+            return make_response(
+                jsonify({"Error": f"No library '{post_data.library_key()}' "
+                               f"currently exists."}), 200
+            )
+
+        return make_response(
+            collection.get_journal_data(post_data.journal_filename),
+            200
+        )
 
     @app.post("/journals/getUpdates")
     def get_journal_updates():

--- a/backend/src/jv2backend/journalRoutes.py
+++ b/backend/src/jv2backend/journalRoutes.py
@@ -5,7 +5,7 @@
 import logging
 from flask import Flask, jsonify, request, make_response
 from flask.wrappers import Response as FlaskResponse
-
+from jv2backend.utils import url_join
 from jv2backend.requestData import RequestData, InvalidRequest
 from jv2backend.journalLibrary import JournalLibrary
 
@@ -30,16 +30,22 @@ def add_routes(
                  journals
         """
         try:
-            postData = RequestData(request.json,
-                                   require_journal_file=True)
+            post_data = RequestData(request.json,
+                                    require_journal_file=True)
         except InvalidRequest as exc:
             return make_response(jsonify({"Error": str(exc)}), 200)
 
-        logging.debug(f"Listing journals for {postData.source_id}: "
-                      f"{postData.journal_file_url()}")
+        logging.debug(f"Listing journals for {post_data.source_id}: "
+                      f"{post_data.journal_file_url()}")
 
         # Parse the journal index
-        return journalLibrary.get_index(postData)
+        return make_response(journalLibrary.get_index(
+            post_data.source_type,
+            post_data.library_key(),
+            url_join(post_data.journal_root_url, post_data.directory),
+            post_data.journal_filename,
+            url_join(post_data.run_data_root_url, post_data.directory)
+        ), 200)
 
     @app.post("/journals/get")
     def get_journal_data() -> FlaskResponse:

--- a/backend/src/jv2backend/journalRoutes.py
+++ b/backend/src/jv2backend/journalRoutes.py
@@ -124,14 +124,25 @@ def add_routes(
         :return: A JSON-formatted list of run data, or None
         """
         try:
-            postData = RequestData(request.json,
-                                   require_value_map=True)
+            post_data = RequestData(request.json,
+                                    require_value_map=True)
         except InvalidRequest as exc:
             return jsonify({"Error": str(exc)})
 
-        logging.debug(f"Search {postData.library_key()} from...")
+        logging.debug(f"Search {post_data.library_key()}...")
 
-        return journalLibrary.search_collection(postData)
+        collection = journalLibrary[post_data.library_key()]
+        if collection is None:
+            return make_response(jsonify(
+                {"Error": f"No collection '{post_data.library_key()}' "
+                          f"currently exists."}),
+                200
+            )
+
+        return make_response(
+            collection.search(post_data.value_map),
+            200
+        )
 
     # ---- TO BE CONVERTED TO REMOVE CYCLE / INSTRUMENT SPECIFICS
 

--- a/backend/src/jv2backend/journalRoutes.py
+++ b/backend/src/jv2backend/journalRoutes.py
@@ -90,15 +90,26 @@ def add_routes(
         :return: A JSON-formatted list of new run data, or None
         """
         try:
-            postData = RequestData(request.json,
-                                   require_journal_file=True)
+            post_data = RequestData(request.json,
+                                    require_journal_file=True)
         except InvalidRequest as exc:
             return make_response(jsonify({"Error": str(exc)}), 200)
 
-        logging.debug(f"Get journal {postData.journal_file_url()} from source "
-                      f"{postData.library_key()}")
+        logging.debug(f"Get journal {post_data.journal_file_url()} updates "
+                      f"from source {post_data.library_key()}")
 
-        return journalLibrary.get_journal_data_updates(postData)
+        collection = journalLibrary[post_data.library_key()]
+        if collection is None:
+            return make_response(jsonify(
+                {"Error": f"No collection '{post_data.library_key()}' "
+                          f"currently exists."}),
+                200
+            )
+
+        return make_response(
+            collection.get_updates(post_data.journal_filename),
+            200
+        )
 
     @app.post("/journals/search")
     def search() -> FlaskResponse:

--- a/backend/src/jv2backend/tests/test_networkJournals.py
+++ b/backend/src/jv2backend/tests/test_networkJournals.py
@@ -123,23 +123,21 @@ def test_parse_isis_journal_file(app, journal_file):
         assert "Error" not in index_response
         assert "TestID/" + FAKE_INSTRUMENT_NAME in library
 
-        journal = library.get_journal_data(run_data_request)
-        journal_response = json.loads(journal.data)
+        collection = library["TestID/" + FAKE_INSTRUMENT_NAME]
+        journal_response = json.loads(collection.get_journal_data(journal_file))
         assert "Error" not in journal_response
         assert len(journal_response) == 3
 
-def test_missing_journal_file(app,):
+def test_missing_journal_file(app):
     library = jv2backend.journalLibrary.JournalLibrary({})
-
-    run_data_request = RequestData(_create_request_dict({"journalFilename": FAKE_JOURNAL_FILE_MISSING}), require_journal_file=True)
 
     with app.app_context():
         index_response = _get_library_index(library)
         assert "Error" not in index_response
         assert "TestID/" + FAKE_INSTRUMENT_NAME in library
 
-        journal = library.get_journal_data(run_data_request)
-        journal_response = json.loads(journal.data)
+        collection = library["TestID/" + FAKE_INSTRUMENT_NAME]
+        journal_response = json.loads(collection.get_journal_data(FAKE_JOURNAL_FILE_MISSING))
         assert "Error" in journal_response
 
 

--- a/backend/src/jv2backend/tests/test_networkJournals.py
+++ b/backend/src/jv2backend/tests/test_networkJournals.py
@@ -2,13 +2,12 @@
 # Copyright (c) 2023 Team JournalViewer and contributors
 
 import pytest
-from flask import Flask
-from typing import Callable
 import logging
 from pathlib import Path
 from jv2backend.utils import url_join
 from jv2backend.app import create_app
 from jv2backend.requestData import RequestData
+from jv2backend.journal import SourceType
 import jv2backend.journalLibrary
 import datetime
 import requests_mock
@@ -57,6 +56,16 @@ def _create_request_dict(updated_keys: {} = {}) -> {}:
     result.update(updated_keys)
     return result
 
+def _get_library_index(library: jv2backend.journalLibrary.JournalLibrary) -> str:
+    """Retrieve library index"""
+    return json.loads(library.get_index(
+        SourceType.Network,
+        "TestID/" + FAKE_INSTRUMENT_NAME,
+        url_join(FAKE_SERVER_ADDRESS, FAKE_INSTRUMENT_NAME),
+        "journal_main.xml",
+        "/fake/data/directory"
+    ))
+
 @pytest.fixture()
 def app(requests_mock):
     app = create_app(activate_cache=False)
@@ -90,11 +99,9 @@ def app(requests_mock):
 
 def test_parse_isis_journal_index(app):
     library = jv2backend.journalLibrary.JournalLibrary({})
-    index_request = RequestData(_create_request_dict(), require_journal_file=True)
 
     with app.app_context():
-        index = library.get_index(index_request)
-        response = json.loads(index.data)
+        response = _get_library_index(library)
 
     assert "Error" not in response
     assert "TestID/" + FAKE_INSTRUMENT_NAME in library
@@ -109,13 +116,10 @@ def test_parse_isis_journal_index(app):
 def test_parse_isis_journal_file(app, journal_file):
     library = jv2backend.journalLibrary.JournalLibrary({})
 
-    index_request = RequestData(_create_request_dict(), require_journal_file=True)
-
     run_data_request = RequestData(_create_request_dict({"journalFilename": journal_file}), require_journal_file=True)
 
     with app.app_context():
-        index = library.get_index(index_request)
-        index_response = json.loads(index.data)
+        index_response = _get_library_index(library)
         assert "Error" not in index_response
         assert "TestID/" + FAKE_INSTRUMENT_NAME in library
 
@@ -127,13 +131,10 @@ def test_parse_isis_journal_file(app, journal_file):
 def test_missing_journal_file(app,):
     library = jv2backend.journalLibrary.JournalLibrary({})
 
-    index_request = RequestData(_create_request_dict(), require_journal_file=True)
-
     run_data_request = RequestData(_create_request_dict({"journalFilename": FAKE_JOURNAL_FILE_MISSING}), require_journal_file=True)
 
     with app.app_context():
-        index = library.get_index(index_request)
-        index_response = json.loads(index.data)
+        index_response = _get_library_index(library)
         assert "Error" not in index_response
         assert "TestID/" + FAKE_INSTRUMENT_NAME in library
 
@@ -145,14 +146,11 @@ def test_missing_journal_file(app,):
 def test_get_journal_file_updates(app):
     library = jv2backend.journalLibrary.JournalLibrary({})
 
-    index_request = RequestData(_create_request_dict(), require_journal_file=True)
-
     run_data_request = RequestData(_create_request_dict({"journalFilename": FAKE_JOURNAL_FILE_A}), require_journal_file=True)
 
     # Assemble the collection in the library and load in the full journal data
     with app.app_context():
-        index = library.get_index(index_request)
-        index_response = json.loads(index.data)
+        index_response = _get_library_index(library)
         assert "Error" not in index_response
         assert "TestID/" + FAKE_INSTRUMENT_NAME in library
 
@@ -195,14 +193,11 @@ def test_get_journal_file_updates(app):
 def test_get_journal_file_updates_for_empty_journal(app):
     library = jv2backend.journalLibrary.JournalLibrary({})
 
-    index_request = RequestData(_create_request_dict(), require_journal_file=True)
-
     run_data_request = RequestData(_create_request_dict({"journalFilename": FAKE_JOURNAL_FILE_A}), require_journal_file=True)
 
     # Assemble the collection in the library
     with app.app_context():
-        index = library.get_index(index_request)
-        index_response = json.loads(index.data)
+        index_response = _get_library_index(library)
         assert "Error" not in index_response
         assert "TestID/" + FAKE_INSTRUMENT_NAME in library
 

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -274,5 +274,8 @@ void Backend::generateJournals(const JournalSource &source, HttpRequestWorker::H
     if (source.type() == JournalSource::IndexingType::Network)
         throw(std::runtime_error("Can't generate journals for a network source.\n"));
 
-    postRequest(createRoute("generate/go"), source.sourceObjectData(), handler);
+    auto data = source.sourceObjectData();
+    data["sortKey"] = JournalSource::dataOrganisationTypeSortKey(source.runDataOrganisation());
+
+    postRequest(createRoute("generate/go"), data, handler);
 }

--- a/frontend/journalSource.cpp
+++ b/frontend/journalSource.cpp
@@ -44,6 +44,20 @@ QString JournalSource::dataOrganisationType(JournalSource::DataOrganisationType 
     }
 }
 
+// Return sort key associated to specified DataOrganisationType
+QString JournalSource::dataOrganisationTypeSortKey(JournalSource::DataOrganisationType type)
+{
+    switch (type)
+    {
+        case (DataOrganisationType::Directory):
+            return "data_directory";
+        case (DataOrganisationType::RBNumber):
+            return "experiment_identifier";
+        default:
+            throw(std::runtime_error("DataOrganisationType not known and can't be converted to a QString.\n"));
+    }
+}
+
 // Convert text string to DataOrganisationType
 JournalSource::DataOrganisationType JournalSource::dataOrganisationType(QString typeString)
 {
@@ -223,7 +237,6 @@ QJsonObject JournalSource::sourceObjectData() const
     if (instrumentSubdirectories_)
         data["directory"] = currentInstrument_ ? currentInstrument_->get().journalDirectory() : "UNKNOWN";
     data["runDataRootUrl"] = runDataRootUrl_;
-    data["dataOrganisation"] = dataOrganisationType(runDataOrganisation_);
     return data;
 }
 

--- a/frontend/journalSource.h
+++ b/frontend/journalSource.h
@@ -34,6 +34,8 @@ class JournalSource
     };
     // Return text string for specified DataOrganisationType
     static QString dataOrganisationType(DataOrganisationType type);
+    // Return sort key associated to specified DataOrganisationType
+    static QString dataOrganisationTypeSortKey(JournalSource::DataOrganisationType type);
     // Convert text string to DataOrganisationType
     static DataOrganisationType dataOrganisationType(QString typeString);
     // JournalSource States


### PR DESCRIPTION
This PR puts an end to passing `RequestData` objects down to our core backend classes, instead limiting their use as data carriers to the backend routes, from the frontend, at which point the relevant information is extracted and passed on.

Closes #263.