### PR TITLE
289 Archive Location Flag

### DIFF
--- a/frontend/CMakeLists.txt
+++ b/frontend/CMakeLists.txt
@@ -50,6 +50,8 @@ qt6_add_executable(
   # Backend
   backend.cpp
   # Main Window
+  args.cpp
+  args.h
   data.cpp
   filtering.cpp
   finding.cpp

--- a/frontend/args.cpp
+++ b/frontend/args.cpp
@@ -1,26 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2023 Team JournalViewer and contributors
 
-#pragma once
-
-#include <QString>
+#include "args.h"
 
 namespace CLIArgs
 {
 /*
- * Argument Name Strings
- */
-const inline static QString LogLevel = QStringLiteral("log-level");
-
-/*
  * Environment Variables
  */
-// Environment variable prefix - must match that defined in backend/config module
-constexpr auto ENVIRON_NAME_PREFIX = "JV2_";
-
 /**
  * Take a program argument name and convert to a backend environment variable name.
  * Replace '-' with '_' and add prefix
  */
-QString argToEnvironName(QString argName);
+QString argToEnvironName(QString argName) { return ENVIRON_NAME_PREFIX + argName.replace("-", "_").toUpper(); }
 }; // namespace CLIArgs

--- a/frontend/args.h
+++ b/frontend/args.h
@@ -8,6 +8,4 @@
 struct Args
 {
     const inline static QString LogLevel = QStringLiteral("log-level");
-    const inline static QString RunLocatorClass = QStringLiteral("run-locator-class");
-    const inline static QString RunLocatorPrefix = QStringLiteral("run-locator-prefix");
 };

--- a/frontend/args.h
+++ b/frontend/args.h
@@ -11,6 +11,8 @@ namespace CLIArgs
  * Argument Name Strings
  */
 const inline static QString LogLevel = QStringLiteral("log-level");
+const inline static QString NoIDAaaS = QStringLiteral("no-idaaas");
+const inline static QString NoISISArchive = QStringLiteral("no-isis-archive");
 
 /*
  * Environment Variables

--- a/frontend/args.h
+++ b/frontend/args.h
@@ -13,6 +13,7 @@ namespace CLIArgs
 const inline static QString LogLevel = QStringLiteral("log-level");
 const inline static QString NoIDAaaS = QStringLiteral("no-idaaas");
 const inline static QString NoISISArchive = QStringLiteral("no-isis-archive");
+const inline static QString ISISArchiveDirectory = QStringLiteral("isis-archive-dir");
 
 /*
  * Environment Variables

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -8,18 +8,6 @@
 #include <QCommandLineParser>
 #include <QProcessEnvironment>
 
-namespace
-{
-// This must match that defined in backend/config module
-constexpr auto ENVIRON_NAME_PREFIX = "JV2_";
-
-/**
- * Take a program argument name and convert to a backend environment variable name.
- * Replace '-' with '_' and add prefix
- */
-QString argToEnvironName(QString argName) { return ENVIRON_NAME_PREFIX + argName.replace("-", "_").toUpper(); }
-} // namespace
-
 Backend::Backend(const QCommandLineParser &args) : process_()
 {
     configureProcessArgs(args);
@@ -56,21 +44,20 @@ void Backend::configureProcessArgs(const QCommandLineParser &args)
                 << "120"
                 << "--timeout"
                 << "120";
-    if (!args.isSet(Args::LogLevel))
-        backendArgs << "--log-level"
-                    << "debug";
+    if (args.isSet(CLIArgs::LogLevel))
+        backendArgs << "--log-level" << args.value(CLIArgs::LogLevel);
     backendArgs << "jv2backend.app:create_app()";
 
     process_.setArguments(backendArgs);
     process_.setProcessChannelMode(QProcess::ForwardedChannels);
 }
 
-// Configure backend process environments
+// Configure backend process environment
 void Backend::configureEnvironment(const QCommandLineParser &args)
 {
     QProcessEnvironment env;
-    if (args.isSet(Args::LogLevel))
-        env.insert(argToEnvironName(Args::LogLevel), args.value(Args::LogLevel));
+    //    if (args.isSet(CLIArgs::AdditionalOption))
+    //        env.insert(CLIArgs::argToEnvironName(CLIArgs::AdditionalOption), args.value(CLIArgs::AdditionalOption));
 
     env.insert(QProcessEnvironment::systemEnvironment());
     process_.setProcessEnvironment(env);

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -69,17 +69,9 @@ void Backend::configureProcessArgs(const QCommandLineParser &args)
 void Backend::configureEnvironment(const QCommandLineParser &args)
 {
     QProcessEnvironment env;
-    if (args.isSet(Args::RunLocatorClass))
-        env.insert(argToEnvironName(Args::RunLocatorClass), args.value(Args::RunLocatorClass));
-    if (args.isSet(Args::RunLocatorPrefix))
-        env.insert(argToEnvironName(Args::RunLocatorPrefix), args.value(Args::RunLocatorPrefix));
+    if (args.isSet(Args::LogLevel))
+        env.insert(argToEnvironName(Args::LogLevel), args.value(Args::LogLevel));
 
-    if (env.isEmpty())
-    {
-        qDebug() << "Configured additional environment variables for backend:";
-        for (const auto &keyValue : env.toStringList())
-            qDebug() << keyValue;
-    }
     env.insert(QProcessEnvironment::systemEnvironment());
     process_.setProcessEnvironment(env);
 }

--- a/frontend/journalSources.cpp
+++ b/frontend/journalSources.cpp
@@ -26,7 +26,11 @@ void MainWindow::setUpStandardJournalSources(QCommandLineParser &cliParser)
         isisArchive->setJournalOrganisationByInstrument(Instrument::PathType::AltNDXName);
         isisArchive->setRunDataOrganisationByInstrument(Instrument::PathType::NDXName);
         isisArchive->setJournalLocation("http://data.isis.rl.ac.uk/journals", "journal_main.xml");
-        isisArchive->setRunDataLocation(settings.value("ISISArchiveDataUrl", "/archive").toString());
+        isisArchive->setRunDataLocation(settings
+                                            .value("ISISArchiveDataUrl", cliParser.isSet(CLIArgs::ISISArchiveDirectory)
+                                                                             ? cliParser.value(CLIArgs::ISISArchiveDirectory)
+                                                                             : "/archive")
+                                            .toString());
     }
 
     // IDAaaS RB Directories

--- a/frontend/journalSources.cpp
+++ b/frontend/journalSources.cpp
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2023 Team JournalViewer and contributors
 
+#include "args.h"
 #include "journalSourcesDialog.h"
 #include "mainWindow.h"
+#include <QCommandLineParser>
 #include <QDomDocument>
 #include <QMessageBox>
 #include <QSettings>
@@ -12,24 +14,30 @@
  */
 
 // Set up standard journal sources
-void MainWindow::setUpStandardJournalSources()
+void MainWindow::setUpStandardJournalSources(QCommandLineParser &cliParser)
 {
     QSettings settings(QSettings::IniFormat, QSettings::UserScope, "ISIS", "jv2");
 
     // The main ISIS Archive
-    auto &isisArchive =
-        journalSources_.emplace_back(std::make_unique<JournalSource>("ISIS Archive", JournalSource::IndexingType::Network));
-    isisArchive->setJournalOrganisationByInstrument(Instrument::PathType::AltNDXName);
-    isisArchive->setRunDataOrganisationByInstrument(Instrument::PathType::NDXName);
-    isisArchive->setJournalLocation("http://data.isis.rl.ac.uk/journals", "journal_main.xml");
-    isisArchive->setRunDataLocation(settings.value("ISISArchiveDataUrl", "/archive").toString());
+    if (!cliParser.isSet(CLIArgs::NoISISArchive))
+    {
+        auto &isisArchive =
+            journalSources_.emplace_back(std::make_unique<JournalSource>("ISIS Archive", JournalSource::IndexingType::Network));
+        isisArchive->setJournalOrganisationByInstrument(Instrument::PathType::AltNDXName);
+        isisArchive->setRunDataOrganisationByInstrument(Instrument::PathType::NDXName);
+        isisArchive->setJournalLocation("http://data.isis.rl.ac.uk/journals", "journal_main.xml");
+        isisArchive->setRunDataLocation(settings.value("ISISArchiveDataUrl", "/archive").toString());
+    }
 
     // IDAaaS RB Directories
-    auto &idaaasRB =
-        journalSources_.emplace_back(std::make_unique<JournalSource>("IDAaaS", JournalSource::IndexingType::Generated));
-    idaaasRB->setRunDataOrganisationByInstrument(Instrument::PathType::Name, true);
-    idaaasRB->setRunDataLocation("/mnt/ceph/instrument_data_cache");
-    idaaasRB->setDataOrganisation(JournalSource::DataOrganisationType::RBNumber);
+    if (!cliParser.isSet(CLIArgs::NoIDAaaS))
+    {
+        auto &idaaasRB =
+            journalSources_.emplace_back(std::make_unique<JournalSource>("IDAaaS", JournalSource::IndexingType::Generated));
+        idaaasRB->setRunDataOrganisationByInstrument(Instrument::PathType::Name, true);
+        idaaasRB->setRunDataLocation("/mnt/ceph/instrument_data_cache");
+        idaaasRB->setDataOrganisation(JournalSource::DataOrganisationType::RBNumber);
+    }
 }
 
 // Find the specified journal source
@@ -78,7 +86,8 @@ void MainWindow::setCurrentJournalSource(JournalSource *source, std::optional<QS
 
     updateForCurrentSource();
 
-    backend_.getJournalIndex(currentJournalSource(), [&](HttpRequestWorker *worker) { handleListJournals(worker); });
+    backend_.getJournalIndex(currentJournalSource(),
+                             [&](HttpRequestWorker *worker) { handleListJournals(worker, goToJournal); });
 }
 
 // Return current journal source

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -55,13 +55,7 @@ CommandLineParseResult parseCommandLine(const QApplication &app, QCommandLinePar
     parser->setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
     parser->setApplicationDescription("Journal Viewer 2");
     auto helpOption = parser->addHelpOption();
-    // clang-format off
-    parser->addOptions({
-        {Args::LogLevel, "Log level for the backend. Matches gunicorn log levels: info, debug", "loglevel"},
-        {Args::RunLocatorClass, "Name of class used to located run data. Fully-qualified Python module.class name is required.", "class"},
-        {Args::RunLocatorPrefix, "A prefix given to the run locator, setting the base path for all run files.", "prefix"}
-    });
-    // clang-format on
+    parser->addOptions({{Args::LogLevel, "Log level for the backend. Matches gunicorn log levels: info, debug", "loglevel"}});
 
     if (!parser->parse(app.arguments()))
     {

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -2,68 +2,32 @@
 // Copyright (c) 2023 Team JournalViewer and contributors
 
 #include "args.h"
-#include "backend.h"
 #include "mainWindow.h"
 #include <QApplication>
 #include <QCommandLineParser>
-#include <QProcess>
-#include <QThread>
-
-namespace
-{
-
-enum CommandLineParseResult
-{
-    CommandLineOk,
-    CommandLineError,
-    CommandLineHelpRequested
-};
-} // namespace
-
-// Forward declaration of parsing
-CommandLineParseResult parseCommandLine(const QApplication &, QCommandLineParser *, QString *);
 
 int main(int argc, char *argv[])
 {
     // Configure the main application early to create an event loop
     QApplication application(argc, argv);
-    application.setWindowIcon(QIcon(":/icon"));
+    QApplication::setWindowIcon(QIcon(":/icon"));
 
-    // Command-line arguments
+    // Set up and parse command-line arguments
     QCommandLineParser parser;
-    QString errorMessage;
-    switch (parseCommandLine(application, &parser, &errorMessage))
+    parser.setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
+    parser.setApplicationDescription("Journal Viewer 2");
+    auto helpOption = parser.addHelpOption();
+    parser.addOptions({{CLIArgs::LogLevel, "Log level for the backend. Matches gunicorn log levels: info, debug", "loglevel"}});
+
+    if (!parser.parse(QApplication::arguments()))
     {
-        case CommandLineParseResult::CommandLineHelpRequested:
-            return 0;
-        case CommandLineParseResult::CommandLineError:
-        {
-            qInfo() << errorMessage;
-            return 1;
-        }
-        case CommandLineParseResult::CommandLineOk:
-            break;
+        qInfo() << parser.errorText();
+        return 1;
     }
+    if (parser.isSet(helpOption))
+        parser.showHelp();
 
     MainWindow window(parser);
     window.show();
-    return application.exec();
-}
-
-CommandLineParseResult parseCommandLine(const QApplication &app, QCommandLineParser *parser, QString *errorMessage)
-{
-    parser->setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
-    parser->setApplicationDescription("Journal Viewer 2");
-    auto helpOption = parser->addHelpOption();
-    parser->addOptions({{Args::LogLevel, "Log level for the backend. Matches gunicorn log levels: info, debug", "loglevel"}});
-
-    if (!parser->parse(app.arguments()))
-    {
-        *errorMessage = parser->errorText();
-        return CommandLineError;
-    }
-    if (parser->isSet(helpOption))
-        return CommandLineHelpRequested;
-
-    return CommandLineOk;
+    return QApplication::exec();
 }

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -17,7 +17,9 @@ int main(int argc, char *argv[])
     parser.setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
     parser.setApplicationDescription("Journal Viewer 2");
     auto helpOption = parser.addHelpOption();
-    parser.addOptions({{CLIArgs::LogLevel, "Log level for the backend. Matches gunicorn log levels: info, debug", "loglevel"}});
+    parser.addOptions({{CLIArgs::LogLevel, "Log level for the backend. Matches gunicorn log levels: info, debug", "loglevel"},
+                       {CLIArgs::NoIDAaaS, "Don't automatically define the IDAaaS source"},
+                       {CLIArgs::NoISISArchive, "Don't automatically define the ISIS Archive source"}});
 
     if (!parser.parse(QApplication::arguments()))
     {

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -17,9 +17,11 @@ int main(int argc, char *argv[])
     parser.setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
     parser.setApplicationDescription("Journal Viewer 2");
     auto helpOption = parser.addHelpOption();
-    parser.addOptions({{CLIArgs::LogLevel, "Log level for the backend. Matches gunicorn log levels: info, debug", "loglevel"},
-                       {CLIArgs::NoIDAaaS, "Don't automatically define the IDAaaS source"},
-                       {CLIArgs::NoISISArchive, "Don't automatically define the ISIS Archive source"}});
+    parser.addOptions(
+        {{CLIArgs::ISISArchiveDirectory, "Path to directory / mountpoint containing main ISIS Archive run data", "directory"},
+         {CLIArgs::LogLevel, "Log level for the backend. Matches gunicorn log levels: info, debug", "log level"},
+         {CLIArgs::NoIDAaaS, "Don't automatically define the IDAaaS source"},
+         {CLIArgs::NoISISArchive, "Don't automatically define the ISIS Archive source"}});
 
     if (!parser.parse(QApplication::arguments()))
     {

--- a/frontend/mainWindow.cpp
+++ b/frontend/mainWindow.cpp
@@ -18,7 +18,7 @@ MainWindow::MainWindow(QCommandLineParser &cliParser) : QMainWindow(), backend_(
     setWindowTitle(QString("JournalViewer 2 (v%1)").arg(JV2VERSION));
 
     // Set up standard journal sources and get any user-defined ones
-    setUpStandardJournalSources();
+    setUpStandardJournalSources(cliParser);
     getUserJournalSources();
     journalSourceModel_.setData(journalSources_);
 

--- a/frontend/mainWindow.h
+++ b/frontend/mainWindow.h
@@ -74,11 +74,11 @@ class MainWindow : public QMainWindow
 
     private:
     // Set up standard journal sources
-    void setUpStandardJournalSources();
-    // Set current journal source
-    void setCurrentJournalSource(JournalSource *source, std::optional<QString> goToJournal = {});
+    void setUpStandardJournalSources(QCommandLineParser &cliParser);
     // Find the specified journal source
     JournalSource *findJournalSource(const QString &name);
+    // Set current journal source
+    void setCurrentJournalSource(JournalSource *source, std::optional<QString> goToJournal = {});
     // Return current journal source
     JournalSource *currentJournalSource() const;
     // Return selected journal in current source (assuming one is selected)


### PR DESCRIPTION
This PR overhauls the CLI option parsing, and adds a few extra useful features such as the ability to disable creation of the standard sources, and to explicitly set the location of the ISIS Archive directory on startup.

Closes #289.
Closes #283.