### PR TITLE
255 Basic Search Everywhere

### DIFF
--- a/backend/src/jv2backend/app.py
+++ b/backend/src/jv2backend/app.py
@@ -7,11 +7,13 @@ import logging.config
 from flask import Flask
 import jv2backend.routes.journal
 import jv2backend.routes.generate
+import jv2backend.routes.acquisition
 import jv2backend.routes.nexus
 import jv2backend.routes.server
 import jv2backend.main.library
 import jv2backend.main.generator
 import jv2backend.main.userCache
+import jv2backend.classes.collection
 import xml.etree.ElementTree as ElementTree
 import argparse
 
@@ -29,10 +31,12 @@ def create_app(activate_cache: bool = True) -> Flask:
     # Create our main objects
     journal_generator = jv2backend.main.generator.JournalGenerator()
     journal_library = jv2backend.main.library.JournalLibrary({})
+    journal_acquirer = jv2backend.classes.collection.JournalAcquirer()
 
     # Register Flask routes
     jv2backend.routes.server.add_routes(app, journal_generator)
     jv2backend.routes.journal.add_routes(app, journal_library)
+    jv2backend.routes.acquisition.add_routes(app, journal_acquirer, journal_library)
     jv2backend.routes.generate.add_routes(app, journal_generator, journal_library)
     jv2backend.routes.nexus.add_routes(app, journal_library)
 

--- a/backend/src/jv2backend/classes/collection.py
+++ b/backend/src/jv2backend/classes/collection.py
@@ -486,8 +486,9 @@ class JournalCollection:
             # If the current 'matches' is None then search the whole run data
             # If it is not, then search it instead (chaining searches)
             # If it is ever a size of zero we have excluded all runs
-            logging.debug("Starting loop over run data...")
+            logging.debug("Starting loop over search terms...")
             for field in search_terms:
+                logging.debug(f"... search '{field}' for '{search_terms[field]}'.")
                 matches = jv2backend.main.selector.select(jf.run_data if matches is None
                                           else matches,
                                           field,
@@ -499,6 +500,7 @@ class JournalCollection:
                     break
 
             if matches is None:
+                logging.debug(f"Journal {jf.filename} matched zero runs.")
                 continue
 
             logging.debug(f"Journal {jf.filename} matched {len(matches)} runs.")

--- a/backend/src/jv2backend/classes/collection.py
+++ b/backend/src/jv2backend/classes/collection.py
@@ -478,6 +478,7 @@ class JournalCollection:
 
         for jf in self._journals:
             logging.debug(f"Journal {jf.filename} .....")
+            jf.get_run_data()
             if not jf.has_run_data:
                 continue
             matches = None

--- a/backend/src/jv2backend/main/library.py
+++ b/backend/src/jv2backend/main/library.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from jv2backend.classes.collection import JournalCollection
 from jv2backend.classes.journal import SourceType
+import jv2backend.main.userCache
 import requests
 import logging
 import lxml.etree as etree
@@ -34,15 +35,20 @@ class JournalLibrary:
     def list(self):
         """List contents of library"""
         for c in self._collections:
+            collection = self._collections[c]
             logging.debug(f"Collection '{c}' contains "
-                          f"{self._collections[c].get_journal_count()} "
+                          f"{collection.get_journal_count()} "
                           f"journal files:")
             for j in self._collections[c].journals:
                 if j.has_run_data():
                     logging.debug(f"     {j.get_file_url()} "
                                   f"({j.get_run_count()} run data)")
                 else:
-                    logging.debug(f"     {j.get_file_url()} (not yet loaded)")
+                    if jv2backend.main.userCache.has_data(collection.library_key,
+                                                          j.filename):
+                        logging.debug(f"     {j.get_file_url()} (in cache)")
+                    else:
+                        logging.debug(f"     {j.get_file_url()} (not yet loaded)")
 
     # ---------------- Work Functions
 

--- a/backend/src/jv2backend/routes/acquisition.py
+++ b/backend/src/jv2backend/routes/acquisition.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2023 Team JournalViewer and contributors
+
+import logging
+from flask import Flask, jsonify, request, make_response
+from flask.wrappers import Response as FlaskResponse
+from jv2backend.classes.requestData import RequestData, InvalidRequest
+from jv2backend.classes.collection import JournalAcquirer
+from jv2backend.main.library import JournalLibrary
+
+
+def add_routes(
+    app: Flask,
+    journalAcquirer: JournalAcquirer,
+    journalLibrary: JournalLibrary,
+) -> Flask:
+    """Add routes to the given Flask application."""
+
+    # ---------------- Queries ------------------
+    @app.post("/acquire")
+    def acquire() -> FlaskResponse:
+        """Acquire all data within the specified source. The process will be threaded
+        and run in the background.
+
+        :return: A JSON response containing OK or an error message
+        """
+        try:
+            post_data = RequestData(request.json,
+                                    require_journal_file=True)
+        except InvalidRequest as exc:
+            return make_response(jsonify({"Error": str(exc)}), 200)
+
+        logging.debug(f"Get all journals for '{post_data.library_key()}'")
+
+        collection = journalLibrary[post_data.library_key()]
+        if collection is None:
+            return make_response(
+                jsonify({"Error": f"No library '{post_data.library_key()}' "
+                                  f"currently exists."}), 200
+            )
+
+        return make_response(
+            journalAcquirer.acquire_all_data(collection),
+            200
+        )
+
+    @app.get("/acquire/update")
+    def acquire_update() -> FlaskResponse:
+        """Provide an update on the current background acquisition"""
+        return make_response(journalAcquirer.get_acquisition_update(), 200)
+
+    @app.get("/acquire/stop")
+    def acquire_stop() -> FlaskResponse:
+        """Stop the current background acquisition"""
+        return make_response(journalAcquirer.stop_acquisition(), 200)
+
+    # ------------------------ End Routes -------------------------
+
+    return app

--- a/backend/src/jv2backend/routes/acquisition.py
+++ b/backend/src/jv2backend/routes/acquisition.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-# Copyright (c) 2023 Team JournalViewer and contributors
+# Copyright (c) 2024 Team JournalViewer and contributors
 
 import logging
 from flask import Flask, jsonify, request, make_response

--- a/backend/src/jv2backend/routes/journal.py
+++ b/backend/src/jv2backend/routes/journal.py
@@ -8,6 +8,7 @@ from flask.wrappers import Response as FlaskResponse
 from jv2backend.utils import url_join
 from jv2backend.classes.requestData import RequestData, InvalidRequest
 from jv2backend.main.library import JournalLibrary
+import jv2backend.classes.journal
 
 
 def add_routes(
@@ -168,7 +169,9 @@ def add_routes(
             )
 
         return make_response(
-            collection.search(post_data.value_map),
+            jv2backend.classes.journal.Journal.convert_run_data_to_json_array(
+                collection.search(post_data.value_map)
+            ),
             200
         )
 

--- a/backend/src/jv2backend/routes/journal.py
+++ b/backend/src/jv2backend/routes/journal.py
@@ -111,6 +111,34 @@ def add_routes(
             200
         )
 
+
+    @app.post("/journals/getUncachedJournalCount")
+    def get_uncached_journal_count():
+        """Gets the total number of uncached journals for the source.
+
+        :return: A JSON-formatted number of uncached journals
+        """
+        try:
+            post_data = RequestData(request.json)
+        except InvalidRequest as exc:
+            return make_response(jsonify({"Error": str(exc)}), 200)
+
+        logging.debug(f"Get uncached journal count for source"
+                      "{post_data.library_key()}")
+
+        collection = journalLibrary[post_data.library_key()]
+        if collection is None:
+            return make_response(jsonify(
+                {"Error": f"No collection '{post_data.library_key()}' "
+                          f"currently exists."}),
+                200
+            )
+
+        return make_response(
+            jsonify(collection.get_uncached_journal_count()),
+            200
+        )
+
     @app.post("/journals/search")
     def search() -> FlaskResponse:
         """Search over all available journals in a target source for any runs

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -133,6 +133,24 @@ void Backend::findJournal(const JournalSource *source, int runNo, const HttpRequ
     postRequest(createRoute("journals/findJournal"), data, handler);
 }
 
+// Get all journals for source in background
+void Backend::acquireAllJournals(const JournalSource *source, const HttpRequestWorker::HttpRequestHandler &handler)
+{
+    postRequest(createRoute("acquire"), source->sourceObjectData(), handler);
+}
+
+// Request update on background journal acquisition scan
+void Backend::acquireAllJournalsUpdate(const HttpRequestWorker::HttpRequestHandler &handler)
+{
+    createRequest(createRoute("acquire/update"), handler);
+}
+
+// Stop background journal acquisition scan
+void Backend::acquireAllJournalsStop(const HttpRequestWorker::HttpRequestHandler &handler)
+{
+    createRequest(createRoute("acquire/stop"), handler);
+}
+
 /*
  * NeXuS Endpoints
  */

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -108,6 +108,12 @@ void Backend::getJournalUpdates(const JournalSource *source, const HttpRequestWo
     postRequest(createRoute("journals/getUpdates"), source->currentJournalObjectData(), handler);
 }
 
+// Get number of uncached journals for specified source
+void Backend::getUncachedJournalCount(const JournalSource *source, const HttpRequestWorker::HttpRequestHandler &handler)
+{
+    postRequest(createRoute("journals/getUncachedJournalCount"), source->currentJournalObjectData(), handler);
+}
+
 // Search across all journals for matching runs
 void Backend::search(const JournalSource *source, const std::map<QString, QString> &searchTerms,
                      const HttpRequestWorker::HttpRequestHandler &handler)

--- a/frontend/backend.h
+++ b/frontend/backend.h
@@ -68,6 +68,8 @@ class Backend : public QObject
     void getJournal(const JournalSource *source, const HttpRequestWorker::HttpRequestHandler &handler = {});
     // Get any updates to the specified current journal in the specified source
     void getJournalUpdates(const JournalSource *source, const HttpRequestWorker::HttpRequestHandler &handler = {});
+    // Get number of uncached journals for specified source
+    void getUncachedJournalCount(const JournalSource *source, const HttpRequestWorker::HttpRequestHandler &handler = {});
     // Search across all journals for matching runs
     void search(const JournalSource *source, const std::map<QString, QString> &searchTerms,
                 const HttpRequestWorker::HttpRequestHandler &handler = {});

--- a/frontend/backend.h
+++ b/frontend/backend.h
@@ -73,6 +73,12 @@ class Backend : public QObject
                 const HttpRequestWorker::HttpRequestHandler &handler = {});
     // Find journal containing specified run number
     void findJournal(const JournalSource *source, int runNo, const HttpRequestWorker::HttpRequestHandler &handler = {});
+    // Get all journals for source in background
+    void acquireAllJournals(const JournalSource *source, const HttpRequestWorker::HttpRequestHandler &handler = {});
+    // Request update on background scan
+    void acquireAllJournalsUpdate(const HttpRequestWorker::HttpRequestHandler &handler = {});
+    // Stop background scan
+    void acquireAllJournalsStop(const HttpRequestWorker::HttpRequestHandler &handler = {});
 
     /*
      * NeXuS Endpoints

--- a/frontend/journalSource.h
+++ b/frontend/journalSource.h
@@ -189,6 +189,7 @@ class JournalSource
         Loading,
         OK,
         Generating,
+        Acquiring,
         Error
     };
 

--- a/frontend/journalSource.h
+++ b/frontend/journalSource.h
@@ -81,6 +81,8 @@ class JournalSource
     std::vector<Journal> &journals();
     // Find named journal
     OptionalReferenceWrapper<Journal> findJournal(const QString &name);
+    // Set current journal being displayed
+    void setCurrentJournal(Journal &journal);
     // Set current journal being displayed by name
     void setCurrentJournal(QString name);
     // Set current journal being displayed by index

--- a/frontend/journalSources.cpp
+++ b/frontend/journalSources.cpp
@@ -167,9 +167,50 @@ void MainWindow::on_actionEditSources_triggered()
     storeUserJournalSources();
 }
 
+void MainWindow::on_actionAcquireAllJournalsForSource_triggered()
+{
+    if (!currentJournalSource_)
+        return;
+
+    backend_.acquireAllJournals(currentJournalSource(), [=](HttpRequestWorker *worker) { handleAcquireAllJournals(); });
+}
+
 /*
  * Network Handling
  */
+
+void MainWindow::handleAcquireAllJournals()
+{
+    // Create a timer to ping the backend for an update after 1000 ms
+    auto *pingTimer = new QTimer;
+    pingTimer->setSingleShot(true);
+    pingTimer->setInterval(1000);
+    connect(pingTimer, &QTimer::timeout,
+            [&]()
+            {
+                backend_.acquireAllJournalsUpdate(
+                    [this](HttpRequestWorker *worker)
+                    {
+                        if (worker->response().startsWith("\"NOT_RUNNING"))
+                        {
+                            statusBar()->showMessage("Acquisition of all journals failed...", 5000);
+                        }
+                        else
+                        {
+                            // Update the generator page of the stack
+                            auto nCompleted = worker->jsonResponse()["num_completed"].toInt();
+                            printf("NUM_COMPLETED = %i\n", nCompleted);
+
+                            // Complete?
+                            if (worker->jsonResponse()["complete"].toBool())
+                                printf("ALL DONE!\n");
+                            else
+                                handleAcquireAllJournals();
+                        }
+                    });
+            });
+    pingTimer->start();
+}
 
 // Handle returned journal information for an instrument
 void MainWindow::handleListJournals(HttpRequestWorker *worker, std::optional<QString> journalToLoad)

--- a/frontend/journalSources.cpp
+++ b/frontend/journalSources.cpp
@@ -172,45 +172,13 @@ void MainWindow::on_actionAcquireAllJournalsForSource_triggered()
     if (!currentJournalSource_)
         return;
 
-    backend_.acquireAllJournals(currentJournalSource(), [=](HttpRequestWorker *worker) { handleAcquireAllJournals(); });
+    backend_.acquireAllJournals(currentJournalSource(),
+                                [=](HttpRequestWorker *worker) { handleAcquireAllJournalsForSearch(); });
 }
 
 /*
  * Network Handling
  */
-
-void MainWindow::handleAcquireAllJournals()
-{
-    // Create a timer to ping the backend for an update after 1000 ms
-    auto *pingTimer = new QTimer;
-    pingTimer->setSingleShot(true);
-    pingTimer->setInterval(1000);
-    connect(pingTimer, &QTimer::timeout,
-            [&]()
-            {
-                backend_.acquireAllJournalsUpdate(
-                    [this](HttpRequestWorker *worker)
-                    {
-                        if (worker->response().startsWith("\"NOT_RUNNING"))
-                        {
-                            statusBar()->showMessage("Acquisition of all journals failed...", 5000);
-                        }
-                        else
-                        {
-                            // Update the generator page of the stack
-                            auto nCompleted = worker->jsonResponse()["num_completed"].toInt();
-                            printf("NUM_COMPLETED = %i\n", nCompleted);
-
-                            // Complete?
-                            if (worker->jsonResponse()["complete"].toBool())
-                                printf("ALL DONE!\n");
-                            else
-                                handleAcquireAllJournals();
-                        }
-                    });
-            });
-    pingTimer->start();
-}
 
 // Handle returned journal information for an instrument
 void MainWindow::handleListJournals(HttpRequestWorker *worker, std::optional<QString> journalToLoad)

--- a/frontend/mainWindow.h
+++ b/frontend/mainWindow.h
@@ -89,6 +89,7 @@ class MainWindow : public QMainWindow
     void on_JournalComboBox_currentIndexChanged(int index);
     void on_JournalComboBackToJournalsButton_clicked(bool checked);
     void on_actionEditSources_triggered();
+    void on_actionAcquireAllJournalsForSource_triggered();
 
     private:
     // Handle returned journal information for an instrument
@@ -97,6 +98,8 @@ class MainWindow : public QMainWindow
     void handleGetJournalUpdates(HttpRequestWorker *workers);
     // Handle jump to journal
     void handleJumpToJournal(HttpRequestWorker *worker);
+    // Handle acquire all journal data update
+    void handleAcquireAllJournals();
 
     /*
      * Instruments

--- a/frontend/mainWindow.h
+++ b/frontend/mainWindow.h
@@ -95,11 +95,9 @@ class MainWindow : public QMainWindow
     // Handle returned journal information for an instrument
     void handleListJournals(HttpRequestWorker *worker, std::optional<QString> journalToLoad = {});
     // Handle get journal updates result
-    void handleGetJournalUpdates(HttpRequestWorker *workers);
+    void handleGetJournalUpdates(HttpRequestWorker *worker);
     // Handle jump to journal
     void handleJumpToJournal(HttpRequestWorker *worker);
-    // Handle acquire all journal data update
-    void handleAcquireAllJournals();
 
     /*
      * Instruments
@@ -239,10 +237,23 @@ class MainWindow : public QMainWindow
     /*
      * Search Everywhere
      */
+    private:
+    // Current source being acquired (if any)
+    JournalSource *sourceBeingAcquired_{nullptr};
+
     private slots:
     void on_actionSearchEverywhere_triggered();
+    void on_AcquisitionCancelButton_clicked(bool checked);
 
     private:
+    // Update journal acquisition page for specified source
+    void updateAcquisitionPage(int nCompleted, const QString &lastJournalProcessed);
+
+    private:
+    // Handle pre-search result
+    void handlePreSearchResult(HttpRequestWorker *worker);
+    // Handle acquire all journal data for search
+    void handleAcquireAllJournalsForSearch();
     // Handle search result
     void handleSearchResult(HttpRequestWorker *worker);
 

--- a/frontend/mainWindow.ui
+++ b/frontend/mainWindow.ui
@@ -500,6 +500,90 @@
             </item>
            </layout>
           </widget>
+          <widget class="QWidget" name="AcquisitionPage">
+           <layout class="QVBoxLayout" name="verticalLayout_9">
+            <item>
+             <widget class="QLabel" name="AcquisitionPageLabel">
+              <property name="text">
+               <string>Acquiring all journals for source...</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>281</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_8">
+              <item>
+               <spacer name="horizontalSpacer_7">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QPushButton" name="AcquisitionCancelButton">
+                <property name="text">
+                 <string>Cancel</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_8">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QProgressBar" name="AcquisitionProgressBar">
+              <property name="value">
+               <number>24</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="AcquisitionInfoLabel">
+              <property name="text">
+               <string/>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
           <widget class="QWidget" name="ErrorPage">
            <layout class="QVBoxLayout" name="verticalLayout_7">
             <item>

--- a/frontend/mainWindow.ui
+++ b/frontend/mainWindow.ui
@@ -639,6 +639,7 @@
      <string>&amp;Sources</string>
     </property>
     <addaction name="actionEditSources"/>
+    <addaction name="actionAcquireAllJournalsForSource"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
@@ -742,6 +743,11 @@
   <action name="actionEditSources">
    <property name="text">
     <string>Edit Sources...</string>
+   </property>
+  </action>
+  <action name="actionAcquireAllJournalsForSource">
+   <property name="text">
+    <string>Acquire All Journals</string>
    </property>
   </action>
  </widget>

--- a/frontend/searchDialog.cpp
+++ b/frontend/searchDialog.cpp
@@ -8,6 +8,20 @@ SearchDialog::SearchDialog(QWidget *parent) : QDialog(parent)
 {
     ui_.setupUi(this);
     ui_.ExperimentIdentifierEdit->setValidator(new QIntValidator(0, 9999999, this));
+
+    // Connect check boxes to button update function
+    connect(ui_.RunTitleCheckBox, SIGNAL(clicked(bool)), this, SLOT(updateButtonStates(bool)));
+    connect(ui_.RunNumberCheckBox, SIGNAL(clicked(bool)), this, SLOT(updateButtonStates(bool)));
+    connect(ui_.UserCheckBox, SIGNAL(clicked(bool)), this, SLOT(updateButtonStates(bool)));
+    connect(ui_.RunNumberCheckBox, SIGNAL(clicked(bool)), this, SLOT(updateButtonStates(bool)));
+}
+
+// Update button states to reflect selected options
+void SearchDialog::updateButtonStates(bool dummy)
+{
+    auto searchEnabled = ui_.RunTitleCheckBox->isChecked() || ui_.RunNumberCheckBox->isChecked() ||
+                         ui_.UserCheckBox->isChecked() || ui_.RunNumberCheckBox->isChecked();
+    ui_.SearchButton->setEnabled(searchEnabled);
 }
 
 void SearchDialog::on_CancelButton_clicked(bool checked) { reject(); }

--- a/frontend/searchDialog.cpp
+++ b/frontend/searchDialog.cpp
@@ -2,8 +2,13 @@
 // Copyright (c) 2024 Team JournalViewer and contributors
 
 #include "searchDialog.h"
+#include <QIntValidator>
 
-SearchDialog::SearchDialog(QWidget *parent) : QDialog(parent) { ui_.setupUi(this); }
+SearchDialog::SearchDialog(QWidget *parent) : QDialog(parent)
+{
+    ui_.setupUi(this);
+    ui_.ExperimentIdentifierEdit->setValidator(new QIntValidator(0, 9999999, this));
+}
 
 void SearchDialog::on_CancelButton_clicked(bool checked) { reject(); }
 
@@ -17,8 +22,12 @@ std::map<QString, QString> SearchDialog::getQuery()
 
     // Assemble the search query parameters
     std::map<QString, QString> parameters;
+
+    // Run title
     if (ui_.RunTitleCheckBox->isChecked() && !ui_.RunTitleEdit->text().isEmpty())
         parameters["title"] = ui_.RunTitleEdit->text();
+
+    // Run Number
     if (ui_.RunNumberCheckBox->isChecked())
     {
         if (ui_.RunNumberRangeRadio->isChecked())
@@ -29,6 +38,14 @@ std::map<QString, QString> SearchDialog::getQuery()
         else if (ui_.RunNumberAfterRadio->isChecked())
             parameters["run_number"] = QString(">%1").arg(ui_.RunNumberAfterSpinBox->value());
     }
+
+    // User
+    if (ui_.UserCheckBox->isChecked() && !ui_.UserEdit->text().isEmpty())
+        parameters["user_name"] = ui_.UserEdit->text();
+
+    // Experiment Identifier
+    if (ui_.ExperimentIdentifierCheckBox->isChecked() && !ui_.ExperimentIdentifierEdit->text().isEmpty())
+        parameters["experiment_identifier"] = ui_.ExperimentIdentifierEdit->text();
 
     return parameters;
 }

--- a/frontend/searchDialog.h
+++ b/frontend/searchDialog.h
@@ -23,6 +23,8 @@ class SearchDialog : public QDialog
     Ui::SearchDialog ui_;
 
     private slots:
+    // Update button states to reflect selected options
+    void updateButtonStates(bool dummy);
     void on_CancelButton_clicked(bool checked);
     void on_SearchButton_clicked(bool checked);
 

--- a/frontend/searchDialog.ui
+++ b/frontend/searchDialog.ui
@@ -93,7 +93,7 @@
          <string>Run Number</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
        </widget>
       </item>
@@ -253,6 +253,49 @@
           </layout>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="UserCheckBox">
+        <property name="toolTip">
+         <string>Enable matching by run title</string>
+        </property>
+        <property name="text">
+         <string>User</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="UserEdit">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="ExperimentIdentifierEdit">
+        <property name="inputMask">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="ExperimentIdentifierCheckBox">
+        <property name="toolTip">
+         <string>Enable matching by run title</string>
+        </property>
+        <property name="text">
+         <string>RB / XB Number</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
      </layout>

--- a/frontend/searchDialog.ui
+++ b/frontend/searchDialog.ui
@@ -16,7 +16,7 @@
    </font>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Search Everywhere</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/frontend/searching.cpp
+++ b/frontend/searching.cpp
@@ -3,6 +3,7 @@
 
 #include "mainWindow.h"
 #include "searchDialog.h"
+#include <QMessageBox>
 
 /*
  * UI
@@ -10,16 +11,113 @@
 
 void MainWindow::on_actionSearchEverywhere_triggered()
 {
-    SearchDialog searchDialog(this);
+    backend_.getUncachedJournalCount(currentJournalSource(), [=](HttpRequestWorker *worker) { handlePreSearchResult(worker); });
+}
 
-    auto queryParameters = searchDialog.getQuery();
+void MainWindow::on_AcquisitionCancelButton_clicked(bool checked)
+{
+    if (!sourceBeingGenerated_)
+        return;
 
-    backend_.search(currentJournalSource(), queryParameters, [=](HttpRequestWorker *worker) { handleSearchResult(worker); });
+    if (QMessageBox::question(
+            this, "Stop Journal Acquisition?",
+            QString("Are you sure you want to cancel journal acquisition for '%1'?").arg(sourceBeingGenerated_->sourceID())) ==
+        QMessageBox::StandardButton::Yes)
+        backend_.generateBackgroundScanStop([&](HttpRequestWorker *worker) { handleGenerateBackgroundScanStop(worker); });
+}
+
+// Update journal acquisition page for specified source
+void MainWindow::updateAcquisitionPage(int nCompleted, const QString &lastJournalProcessed)
+{
+    ui_.AcquisitionProgressBar->setValue(nCompleted);
+    ui_.AcquisitionInfoLabel->setText(QString("Last journal processed was '%1')").arg(lastJournalProcessed));
 }
 
 /*
  * Network Handlers
  */
+
+// Handle pre-search result
+void MainWindow::handlePreSearchResult(HttpRequestWorker *worker)
+{
+    auto nUncached = worker->response().toInt();
+    qDebug() << "Number of uncached journals = " << nUncached;
+    if (nUncached != 0)
+    {
+        if (QMessageBox::question(this, "Acquire All Journals?",
+                                  "Before a Search Everywhere query can be run all journals for the source must be cached.\n"
+                                  "This only needs to be done once. Do you want to do this now? ") ==
+            QMessageBox::StandardButton::No)
+            return;
+
+        sourceBeingAcquired_ = currentJournalSource();
+
+        // Update the GUI
+        ui_.AcquisitionPageLabel->setText(QString("Acquiring Journals for Source '%1'...\nSource has %2 journals in total.")
+                                              .arg(sourceBeingAcquired_->name())
+                                              .arg(sourceBeingAcquired_->journals().size()));
+        ui_.AcquisitionProgressBar->setMaximum(nUncached);
+        updateAcquisitionPage(0, "<No Journal Acquired>");
+
+        updateForCurrentSource(JournalSource::JournalSourceState::Acquiring);
+
+        backend_.acquireAllJournals(currentJournalSource(),
+                                    [=](HttpRequestWorker *worker) { handleAcquireAllJournalsForSearch(); });
+    }
+    else
+    {
+        SearchDialog searchDialog(this);
+
+        auto queryParameters = searchDialog.getQuery();
+        backend_.search(currentJournalSource(), queryParameters,
+                        [=](HttpRequestWorker *worker) { handleSearchResult(worker); });
+    }
+}
+
+// Handle acquire all journal data for search
+void MainWindow::handleAcquireAllJournalsForSearch()
+{
+    // Create a timer to ping the backend for an update after 1000 ms
+    auto *pingTimer = new QTimer;
+    pingTimer->setSingleShot(true);
+    pingTimer->setInterval(1000);
+    connect(
+        pingTimer, &QTimer::timeout,
+        [&]()
+        {
+            backend_.acquireAllJournalsUpdate(
+                [this](HttpRequestWorker *worker)
+                {
+                    if (worker->response().startsWith("\"NOT_RUNNING"))
+                    {
+                        statusBar()->showMessage("Acquisition of journals failed...", 5000);
+                    }
+                    else
+                    {
+                        // Update the generator page of the stack
+                        auto nCompleted = worker->jsonResponse()["num_completed"].toInt();
+                        auto lastFilename = worker->jsonResponse()["last_filename"].toString();
+                        updateAcquisitionPage(nCompleted, lastFilename);
+
+                        // Complete?
+                        if (worker->jsonResponse()["complete"].toBool())
+                        {
+                            sourceBeingAcquired_->setState(JournalSource::JournalSourceState::Loading);
+
+                            statusBar()->showMessage(
+                                QString("Journal acquisition completed for source '%1'.\n").arg(sourceBeingAcquired_->name()));
+
+                            sourceBeingAcquired_ = nullptr;
+
+                            on_actionSearchEverywhere_triggered();
+                        }
+                        else
+                            handleAcquireAllJournalsForSearch();
+                    }
+                });
+        });
+    pingTimer->start();
+}
 
 // Handle search result
 void MainWindow::handleSearchResult(HttpRequestWorker *worker)

--- a/frontend/searching.cpp
+++ b/frontend/searching.cpp
@@ -91,6 +91,9 @@ void MainWindow::handleAcquireAllJournalsForSearch()
                     if (worker->response().startsWith("\"NOT_RUNNING"))
                     {
                         statusBar()->showMessage("Acquisition of journals failed...", 5000);
+                        if (currentJournalSource() == sourceBeingAcquired_)
+                            updateForCurrentSource(JournalSource::JournalSourceState::Error);
+                        sourceBeingAcquired_ = nullptr;
                     }
                     else
                     {


### PR DESCRIPTION
This PR extends the search capabilities to other quantities and implements backend / frontend acquisition of all journals for a given source, i.e. caching them for use with "Search Everywhere".

## TODO
- [x] Search Dialog - disable "Search" button if no criteria are selected.
- [x] Implement backend check for all data being available for a given source, and call this as a check before attempting a Search Everywhere.
- [x] Tie background journal acquisition updates to a progress bar in the main UI statusbar.