### PR TITLE
Subpath Restrictions

### DIFF
--- a/backend/src/jv2backend/main/generator.py
+++ b/backend/src/jv2backend/main/generator.py
@@ -152,6 +152,8 @@ class JournalGenerator:
         """List available NeXuS files in a directory.
 
         :param data_directory: Target data directory to scan
+        :param root_re_selector: Regular expression used to match relevant
+                                 directories in the root
         :return: A JSON response with the number of NeXuS files located
         """
         # Check if a scan is already in progress
@@ -168,6 +170,8 @@ class JournalGenerator:
             # regexp selector.
             if rootDir == data_directory:
                 dirs[:] = [d for d in dirs if re.match(root_re_selector, d)]
+                logging.debug(f"Root dirs after RE selector "
+                              f"'{root_re_selector}': {dirs}")
 
             # Process files in this directory
             for f in files:

--- a/backend/src/jv2backend/main/generator.py
+++ b/backend/src/jv2backend/main/generator.py
@@ -9,6 +9,7 @@ import hashlib
 import datetime
 import json
 import copy
+import re
 from jv2backend.utils import url_join
 from jv2backend.classes.collection import JournalCollection
 import jv2backend.main.userCache
@@ -147,7 +148,7 @@ class JournalGenerator:
     def __init__(self) -> None:
         self._discovered_files: typing.Dict[str, typing.Any] = {}
 
-    def list_files(self, data_directory: str) -> str:
+    def list_files(self, data_directory: str, root_re_selector: str) -> str:
         """List available NeXuS files in a directory.
 
         :param data_directory: Target data directory to scan
@@ -156,10 +157,19 @@ class JournalGenerator:
         # Check if a scan is already in progress
         # TODO
 
+        # Strip off any trailing slashes from the root_directory
+        data_directory.rstrip("/\\")
+
         # First step, create a dict of all available nxs files in the target
         # directory, organised by folder name
         self._discovered_files = {}
         for rootDir, dirs, files in os.walk(data_directory):
+            # If this is the root (i.e. == "data_directory" then apply the
+            # regexp selector.
+            if rootDir == data_directory:
+                dirs[:] = [d for d in dirs if re.match(root_re_selector, d)]
+
+            # Process files in this directory
             for f in files:
                 if (f.lower().endswith(".nxs") and
                     os.access(url_join(rootDir, f), os.R_OK)):

--- a/backend/src/jv2backend/routes/generate.py
+++ b/backend/src/jv2backend/routes/generate.py
@@ -32,7 +32,8 @@ def add_routes(
         """
         try:
             post_data = RequestData(request.json,
-                                    require_data_directory=True)
+                                    require_data_directory=True,
+                                    require_parameters="rootRegExpSelector")
         except InvalidRequest as exc:
             return make_response(jsonify({"InvalidRequestError": str(exc)}), 200)
 
@@ -40,7 +41,8 @@ def add_routes(
                       f"{post_data.run_data_root_url}...")
 
         return make_response(
-            journalGenerator.list_files(post_data.run_data_root_url),
+            journalGenerator.list_files(post_data.run_data_root_url,
+                                              post_data.parameter("rootRegExpSelector")),
             200
         )
 

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -247,7 +247,7 @@ void Backend::generateBackgroundScan(const JournalSource *source, const HttpRequ
 {
     // Only for disk-based sources
     if (source->type() == JournalSource::IndexingType::Network)
-        throw(std::runtime_error("Can't generate journals for a network source->\n"));
+        throw(std::runtime_error("Can't generate journals for a network source.\n"));
 
     postRequest(createRoute("generate/scan"), source->sourceObjectData(), handler);
 }

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -237,7 +237,7 @@ void Backend::getNexusDetectorAnalysis(const JournalSource *source, int runNo,
 void Backend::generateList(const JournalSource *source, const HttpRequestWorker::HttpRequestHandler &handler)
 {
     auto data = source->currentJournalObjectData();
-    data["rootRegExpSelector"] = source->runDataRootRegexp();
+    data["rootRegExpSelector"] = source->runDataRootRegExp();
 
     postRequest(createRoute("generate/list"), source->currentJournalObjectData(), handler);
 }

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -236,6 +236,9 @@ void Backend::getNexusDetectorAnalysis(const JournalSource *source, int runNo,
 // Generate data file list for the specified source
 void Backend::generateList(const JournalSource *source, const HttpRequestWorker::HttpRequestHandler &handler)
 {
+    auto data = source->currentJournalObjectData();
+    data["rootRegExpSelector"] = source->runDataRootRegexp();
+
     postRequest(createRoute("generate/list"), source->currentJournalObjectData(), handler);
 }
 

--- a/frontend/backend.cpp
+++ b/frontend/backend.cpp
@@ -239,7 +239,7 @@ void Backend::generateList(const JournalSource *source, const HttpRequestWorker:
     auto data = source->currentJournalObjectData();
     data["rootRegExpSelector"] = source->runDataRootRegExp();
 
-    postRequest(createRoute("generate/list"), source->currentJournalObjectData(), handler);
+    postRequest(createRoute("generate/list"), data, handler);
 }
 
 // Scan data files discovered in the specified source

--- a/frontend/journalSource.cpp
+++ b/frontend/journalSource.cpp
@@ -200,6 +200,12 @@ void JournalSource::setRunDataLocation(const QString &runDataRootUrl) { runDataR
 // Return root URL containing associated run data
 const QString &JournalSource::runDataRootUrl() const { return runDataRootUrl_; }
 
+// Set regular expression to select directories directly under the root URL
+void JournalSource::setRunDataRootRegexp(const QString &regexp) { runDataRootRegexp_ = regexp; }
+
+// Return regular expression to select directories directly under the root URL
+const QString &JournalSource::runDataRootRegexp() const { return runDataRootRegexp_; }
+
 /*
  * Generated Data Organisation
  */

--- a/frontend/journalSource.cpp
+++ b/frontend/journalSource.cpp
@@ -201,10 +201,10 @@ void JournalSource::setRunDataLocation(const QString &runDataRootUrl) { runDataR
 const QString &JournalSource::runDataRootUrl() const { return runDataRootUrl_; }
 
 // Set regular expression to select directories directly under the root URL
-void JournalSource::setRunDataRootRegexp(const QString &regexp) { runDataRootRegexp_ = regexp; }
+void JournalSource::setRunDataRootRegExp(const QString &regexp) { runDataRootRegExp_ = regexp; }
 
 // Return regular expression to select directories directly under the root URL
-const QString &JournalSource::runDataRootRegexp() const { return runDataRootRegexp_; }
+const QString &JournalSource::runDataRootRegExp() const { return runDataRootRegExp_; }
 
 /*
  * Generated Data Organisation

--- a/frontend/journalSource.h
+++ b/frontend/journalSource.h
@@ -136,12 +136,18 @@ class JournalSource
     private:
     // Root URL containing associated run data
     QString runDataRootUrl_;
+    // Regular expression to select directories directly under the root URL
+    QString runDataRootRegexp_;
 
     public:
     // Set run data location
     void setRunDataLocation(const QString &runDataRootUrl);
     // Return root URL containing associated run data
     const QString &runDataRootUrl() const;
+    // Set regular expression to select directories directly under the root URL
+    void setRunDataRootRegexp(const QString &regexp);
+    // Return regular expression to select directories directly under the root URL
+    const QString &runDataRootRegexp() const;
 
     /*
      * Generated Data Organisation

--- a/frontend/journalSource.h
+++ b/frontend/journalSource.h
@@ -137,7 +137,7 @@ class JournalSource
     // Root URL containing associated run data
     QString runDataRootUrl_;
     // Regular expression to select directories directly under the root URL
-    QString runDataRootRegexp_;
+    QString runDataRootRegExp_;
 
     public:
     // Set run data location
@@ -145,9 +145,9 @@ class JournalSource
     // Return root URL containing associated run data
     const QString &runDataRootUrl() const;
     // Set regular expression to select directories directly under the root URL
-    void setRunDataRootRegexp(const QString &regexp);
+    void setRunDataRootRegExp(const QString &regexp);
     // Return regular expression to select directories directly under the root URL
-    const QString &runDataRootRegexp() const;
+    const QString &runDataRootRegExp() const;
 
     /*
      * Generated Data Organisation

--- a/frontend/journalSources.cpp
+++ b/frontend/journalSources.cpp
@@ -41,7 +41,7 @@ void MainWindow::setUpStandardJournalSources(QCommandLineParser &cliParser)
         idaaasRB->setRunDataOrganisationByInstrument(Instrument::PathType::Name, true);
         idaaasRB->setRunDataLocation("/mnt/ceph/instrument_data_cache");
         idaaasRB->setDataOrganisation(JournalSource::DataOrganisationType::RBNumber);
-        idaaasRB->setRunDataRootRegexp("[0-9]\\+");
+        idaaasRB->setRunDataRootRegExp("[0-9]\\+");
     }
 }
 

--- a/frontend/journalSources.cpp
+++ b/frontend/journalSources.cpp
@@ -41,7 +41,7 @@ void MainWindow::setUpStandardJournalSources(QCommandLineParser &cliParser)
         idaaasRB->setRunDataOrganisationByInstrument(Instrument::PathType::Name, true);
         idaaasRB->setRunDataLocation("/mnt/ceph/instrument_data_cache");
         idaaasRB->setDataOrganisation(JournalSource::DataOrganisationType::RBNumber);
-        idaaasRB->setRunDataRootRegExp("[0-9]\\+");
+        idaaasRB->setRunDataRootRegExp("^[0-9]+");
     }
 }
 

--- a/frontend/journalSources.cpp
+++ b/frontend/journalSources.cpp
@@ -41,6 +41,7 @@ void MainWindow::setUpStandardJournalSources(QCommandLineParser &cliParser)
         idaaasRB->setRunDataOrganisationByInstrument(Instrument::PathType::Name, true);
         idaaasRB->setRunDataLocation("/mnt/ceph/instrument_data_cache");
         idaaasRB->setDataOrganisation(JournalSource::DataOrganisationType::RBNumber);
+        idaaasRB->setRunDataRootRegexp("[0-9]\\+");
     }
 }
 

--- a/frontend/journalSourcesDialog.cpp
+++ b/frontend/journalSourcesDialog.cpp
@@ -48,6 +48,7 @@ void JournalSourcesDialog::currentSourceChanged(const QModelIndex &currentIndex,
     ui_.JournalInstrumentPathUppercaseCheck->setChecked(currentSource_->isJournalOrganisationByInstrumentUppercased());
     // -- Run Data Location
     ui_.RunDataRootURLEdit->setText(currentSource_->runDataRootUrl());
+    ui_.RunDataRootRegExpEdit->setText(currentSource_->runDataRootRegexp());
     ui_.RunDataInstrumentPathCombo->setCurrentIndex(currentSource_->runDataOrganisationByInstrument());
     ui_.RunDataInstrumentPathUppercaseCheck->setChecked(currentSource_->isRunDataOrganisationByInstrumentUppercased());
     // -- Data Organisation
@@ -133,6 +134,14 @@ void JournalSourcesDialog::on_RunDataRootURLEdit_editingFinished()
         return;
 
     currentSource_->setRunDataLocation(ui_.RunDataRootURLEdit->text());
+}
+
+void JournalSourcesDialog::on_RunDataRootRegExpEdit_editingFinished()
+{
+    if (widgetUpdateLock_ || !currentSource_)
+        return;
+
+    currentSource_->setRunDataRootRegexp(ui_.RunDataRootRegExpEdit->text());
 }
 
 void JournalSourcesDialog::on_RunDataRootURLSelectButton_clicked(bool checked)

--- a/frontend/journalSourcesDialog.cpp
+++ b/frontend/journalSourcesDialog.cpp
@@ -48,7 +48,7 @@ void JournalSourcesDialog::currentSourceChanged(const QModelIndex &currentIndex,
     ui_.JournalInstrumentPathUppercaseCheck->setChecked(currentSource_->isJournalOrganisationByInstrumentUppercased());
     // -- Run Data Location
     ui_.RunDataRootURLEdit->setText(currentSource_->runDataRootUrl());
-    ui_.RunDataRootRegExpEdit->setText(currentSource_->runDataRootRegexp());
+    ui_.RunDataRootRegExpEdit->setText(currentSource_->runDataRootRegExp());
     ui_.RunDataInstrumentPathCombo->setCurrentIndex(currentSource_->runDataOrganisationByInstrument());
     ui_.RunDataInstrumentPathUppercaseCheck->setChecked(currentSource_->isRunDataOrganisationByInstrumentUppercased());
     // -- Data Organisation
@@ -141,7 +141,7 @@ void JournalSourcesDialog::on_RunDataRootRegExpEdit_editingFinished()
     if (widgetUpdateLock_ || !currentSource_)
         return;
 
-    currentSource_->setRunDataRootRegexp(ui_.RunDataRootRegExpEdit->text());
+    currentSource_->setRunDataRootRegExp(ui_.RunDataRootRegExpEdit->text());
 }
 
 void JournalSourcesDialog::on_RunDataRootURLSelectButton_clicked(bool checked)

--- a/frontend/journalSourcesDialog.h
+++ b/frontend/journalSourcesDialog.h
@@ -46,6 +46,7 @@ class JournalSourcesDialog : public QDialog
     void on_JournalInstrumentPathUppercaseCheck_clicked(bool checked);
     // Run Data Location
     void on_RunDataRootURLEdit_editingFinished();
+    void on_RunDataRootRegExpEdit_editingFinished();
     void on_RunDataRootURLSelectButton_clicked(bool checked);
     void on_RunDataInstrumentPathCombo_currentIndexChanged(int index);
     void on_RunDataInstrumentPathUppercaseCheck_clicked(bool checked);

--- a/frontend/journalSourcesDialog.ui
+++ b/frontend/journalSourcesDialog.ui
@@ -242,14 +242,14 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="RunDataInstrumentPathLabel">
             <property name="text">
              <string>Instrument Paths</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QComboBox" name="RunDataInstrumentPathCombo">
             <item>
              <property name="text">
@@ -273,7 +273,7 @@
             </item>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QCheckBox" name="RunDataInstrumentPathUppercaseCheck">
             <property name="text">
              <string>Uppercased</string>
@@ -300,6 +300,16 @@
              </widget>
             </item>
            </layout>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="RunDataRootRegExpLabel">
+            <property name="text">
+             <string>Root Dir RegExp</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="RunDataRootRegExpEdit"/>
           </item>
          </layout>
         </widget>

--- a/frontend/settings.cpp
+++ b/frontend/settings.cpp
@@ -124,7 +124,7 @@ void MainWindow::storeUserJournalSources() const
 
         // Run Data
         settings.setValue("RunDataRootUrl", source->runDataRootUrl());
-        settings.setValue("RunDataRootRegExp", source->runDataRootRegexp());
+        settings.setValue("RunDataRootRegExp", source->runDataRootRegExp());
         settings.setValue("RunDataPathType", Instrument::pathType(source->runDataOrganisationByInstrument()));
         settings.setValue("RunDataPathTypeUppercased", source->isRunDataOrganisationByInstrumentUppercased());
 
@@ -164,7 +164,7 @@ void MainWindow::getUserJournalSources()
 
         // Run Data
         source->setRunDataLocation(settings.value("RunDataRootUrl").toString());
-        source->setRunDataRootRegexp(settings.value("RunDataRootRegExp").toString());
+        source->setRunDataRootRegExp(settings.value("RunDataRootRegExp").toString());
         source->setRunDataOrganisationByInstrument(
             Instrument::pathType(
                 settings.value("RunDataPathType", Instrument::pathType(Instrument::PathType::None)).toString()),

--- a/frontend/settings.cpp
+++ b/frontend/settings.cpp
@@ -124,6 +124,7 @@ void MainWindow::storeUserJournalSources() const
 
         // Run Data
         settings.setValue("RunDataRootUrl", source->runDataRootUrl());
+        settings.setValue("RunDataRootRegExp", source->runDataRootRegexp());
         settings.setValue("RunDataPathType", Instrument::pathType(source->runDataOrganisationByInstrument()));
         settings.setValue("RunDataPathTypeUppercased", source->isRunDataOrganisationByInstrumentUppercased());
 
@@ -163,6 +164,7 @@ void MainWindow::getUserJournalSources()
 
         // Run Data
         source->setRunDataLocation(settings.value("RunDataRootUrl").toString());
+        source->setRunDataRootRegexp(settings.value("RunDataRootRegExp").toString());
         source->setRunDataOrganisationByInstrument(
             Instrument::pathType(
                 settings.value("RunDataPathType", Instrument::pathType(Instrument::PathType::None)).toString()),


### PR DESCRIPTION
This PR adds the ability to filter the root directory of generated sources via a regexp - the specific example is to prevent double-counting of files on IDAaaS by excluding directories starting with "CYCLE" and just take those with years.